### PR TITLE
Set the assets public URL at runtime

### DIFF
--- a/gallery/src/App.js
+++ b/gallery/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import createHistory from 'history/createBrowserHistory'
 import styled from 'styled-components'
-import { BaseStyles } from '@aragon/ui'
+import { AragonApp } from '@aragon/ui'
 import Sidebar from 'comps/Sidebar/Sidebar'
 import PageHome from 'pages/PageHome'
 import PageColors from 'pages/PageColors'
@@ -37,7 +37,7 @@ const preparePages = (path, pages) =>
     path: path + p[2].replace(/^\//, '') + (p[2] === '/' ? '' : '/'),
   }))
 
-const Main = styled.main`
+const Main = styled.div`
   display: flex;
   height: 100%;
   > :first-child {
@@ -73,8 +73,7 @@ class App extends React.Component {
     const { pages, activePage } = this.state
     const Page = activePage && activePage.comp
     return (
-      <div>
-        <BaseStyles />
+      <AragonApp publicUrl="/">
         <Main>
           <Sidebar
             pages={pages}
@@ -83,7 +82,7 @@ class App extends React.Component {
           />
           {Page && <Page title={activePage.name} />}
         </Main>
-      </div>
+      </AragonApp>
     )
   }
 }

--- a/gallery/src/pages/PageButton.js
+++ b/gallery/src/pages/PageButton.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/Button/README.md'
+import readme from 'ui-src/components/Button/README.md'
 import { Button, colors } from '@aragon/ui'
 
 const Container = styled.div`

--- a/gallery/src/pages/PageDropDown.js
+++ b/gallery/src/pages/PageDropDown.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/DropDown/README.md'
+import readme from 'ui-src/components/DropDown/README.md'
 import { DropDown } from '@aragon/ui'
 
 const Container = styled.div`

--- a/gallery/src/pages/PageFooter.js
+++ b/gallery/src/pages/PageFooter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/Footer/README.md'
+import readme from 'ui-src/components/Footer/README.md'
 import { Text, Footer } from '@aragon/ui'
 
 const Container = styled.div`

--- a/gallery/src/pages/PageHeader.js
+++ b/gallery/src/pages/PageHeader.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/Header/README.md'
+import readme from 'ui-src/components/Header/README.md'
 import { Text, Header, colors } from '@aragon/ui'
 
 const Container = styled.div`

--- a/gallery/src/pages/PageIllustratedSection.js
+++ b/gallery/src/pages/PageIllustratedSection.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/IllustratedSection/README.md'
+import readme from 'ui-src/components/IllustratedSection/README.md'
 
 const PageIllustratedSection = ({ title }) => (
   <Page title={title} readme={readme} />

--- a/gallery/src/pages/PagePreFooter.js
+++ b/gallery/src/pages/PagePreFooter.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/PreFooter/README.md'
+import readme from 'ui-src/components/PreFooter/README.md'
 import { PreFooter } from '@aragon/ui'
 
 const PagePreFooter = ({ title }) => (

--- a/gallery/src/pages/PageSection.js
+++ b/gallery/src/pages/PageSection.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/Section/README.md'
+import readme from 'ui-src/components/Section/README.md'
 
 const PageSection = ({ title }) => (
   <Page title={title} readme={readme} />

--- a/gallery/src/pages/PageText.js
+++ b/gallery/src/pages/PageText.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
-import readme from '@aragon/ui/components/Text/README.md'
+import readme from 'ui-src/components/Text/README.md'
 import { Text, colors } from '@aragon/ui'
 
 const Container = styled.div`

--- a/gallery/src/pages/PageTheme.js
+++ b/gallery/src/pages/PageTheme.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { theme } from '@aragon/ui'
 import Page from 'comps/Page/Page'
 import ColorGroup from 'comps/ColorGroup/ColorGroup'
-import readme from '@aragon/ui/theme/README.md'
+import readme from 'ui-src/theme/README.md'
 
 const PageButton = ({ title }) => (
   <Page title={title} readme={readme}>

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -44,12 +44,8 @@ module.exports = {
       '@aragon/ui': path.resolve(__dirname, '..'),
       'ui-src': path.resolve(__dirname, '../src'),
     },
-    modules: [
-      path.join(__dirname, 'node_modules'),
-      path.join(__dirname, '../node_modules'),
-    ],
-  },
-  resolveLoader: {
+
+    // Only needed because @aragon/ui is linked
     modules: [
       path.join(__dirname, 'node_modules'),
       path.join(__dirname, '../node_modules'),

--- a/gallery/webpack.config.js
+++ b/gallery/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = {
   entry: [path.resolve(__dirname, 'src/index.js')],
   devtool: PRODUCTION ? 'source-map' : 'eval',
   devServer: {
-    contentBase: path.join(__dirname, 'public'),
+    contentBase: [path.join(__dirname, '../dist'), path.join(__dirname, 'public')],
     historyApiFallback: true,
   },
   resolve: {
@@ -41,7 +41,8 @@ module.exports = {
       pages: path.resolve(__dirname, 'src/pages'),
       comps: path.resolve(__dirname, 'src/components'),
       src: path.resolve(__dirname, 'src'),
-      '@aragon/ui': path.resolve(__dirname, '../src'),
+      '@aragon/ui': path.resolve(__dirname, '..'),
+      'ui-src': path.resolve(__dirname, '../src'),
     },
     modules: [
       path.join(__dirname, 'node_modules'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
-      "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+      "version": "7.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.32.tgz",
+      "integrity": "sha512-EVq4T1a2GviKiQ75OfxNrGPPhJyXzg9jjORuuwhloZbFdrhT4FHa73sv9OFWBwX7rl2b6bxBVmfxrBQYWYz9tA==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -53,66 +53,65 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
-      "integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+      "version": "7.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.32.tgz",
+      "integrity": "sha512-ysfIt7p72xm5fjSJsv7fMVN/j+EwIdqu8/MJjt6TqB4wM2r6rFRi0ujBTWDkLGQkRB/P5uDV8qcFCHAHnNzmsg==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.31",
-        "@babel/template": "7.0.0-beta.31",
-        "@babel/traverse": "7.0.0-beta.31",
-        "@babel/types": "7.0.0-beta.31"
+        "@babel/helper-get-function-arity": "7.0.0-beta.32",
+        "@babel/template": "7.0.0-beta.32",
+        "@babel/types": "7.0.0-beta.32"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
-      "integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+      "version": "7.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.32.tgz",
+      "integrity": "sha512-bm7lIlizycJQY5SJ3HXWJV4XjSrOt1onzrDcOxUo9FEnKRZDEr/zfi5ar2s5tvvZvve/jGHwZKVKekRw2cjPCQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.31"
+        "@babel/types": "7.0.0-beta.32"
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
-      "integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+      "version": "7.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.32.tgz",
+      "integrity": "sha512-DB9sLgX2mfE29vjAkxHlzLyWr31EO9HaYoAM/UsPSsL70Eudl0i25URwIfQT6S6ckeVFnFP1t6PhERVeV4EAHA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.31",
-        "@babel/types": "7.0.0-beta.31",
-        "babylon": "7.0.0-beta.31",
+        "@babel/code-frame": "7.0.0-beta.32",
+        "@babel/types": "7.0.0-beta.32",
+        "babylon": "7.0.0-beta.32",
         "lodash": "4.17.4"
       },
       "dependencies": {
         "babylon": {
-          "version": "7.0.0-beta.31",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "version": "7.0.0-beta.32",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.32.tgz",
+          "integrity": "sha512-PvAmyP2IJEBVAuE5yVzrTSWCCN9VMa1eGns8w3w6FYD/ivHSUmS7n+F40Fmjn+0nCQSUFR96wP0CqQ4jxTnF4Q==",
           "dev": true
         }
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
-      "integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+      "version": "7.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.32.tgz",
+      "integrity": "sha512-dGe2CLduCIZ/iDkbmnqspQguRy5ARvI+zC8TiwFnsJ2YYO2TWK7x2aEwrbkSmi0iPlBP+Syiag7Idc1qNQq74g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.31",
-        "@babel/helper-function-name": "7.0.0-beta.31",
-        "@babel/types": "7.0.0-beta.31",
-        "babylon": "7.0.0-beta.31",
+        "@babel/code-frame": "7.0.0-beta.32",
+        "@babel/helper-function-name": "7.0.0-beta.32",
+        "@babel/types": "7.0.0-beta.32",
+        "babylon": "7.0.0-beta.32",
         "debug": "3.1.0",
-        "globals": "10.3.0",
+        "globals": "10.4.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
       },
       "dependencies": {
         "babylon": {
-          "version": "7.0.0-beta.31",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "version": "7.0.0-beta.32",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.32.tgz",
+          "integrity": "sha512-PvAmyP2IJEBVAuE5yVzrTSWCCN9VMa1eGns8w3w6FYD/ivHSUmS7n+F40Fmjn+0nCQSUFR96wP0CqQ4jxTnF4Q==",
           "dev": true
         },
         "debug": {
@@ -125,17 +124,17 @@
           }
         },
         "globals": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.3.0.tgz",
-          "integrity": "sha512-1g6qO5vMbiPHbRTDtR9JVjRkAhkgH4nSANYGyx1eOfqgxcMnYMMD+7MjmjfzXjwFpVUE/7/NzF+jQxYE7P4r7A==",
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
-      "integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+      "version": "7.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.32.tgz",
+      "integrity": "sha512-w8+wzVcYCMb9OfaBfay2Vg5hyj7UfBX6qQtA+kB0qsW1h1NH/7xHMwvTZNqkuFBwjz5wxGS2QmaIcC3HH+UoxA==",
       "dev": true,
       "requires": {
         "esutils": "2.0.2",
@@ -182,9 +181,9 @@
       }
     },
     "ajv": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
-      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
+      "integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -344,9 +343,9 @@
       }
     },
     "async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4"
@@ -390,7 +389,7 @@
         "chokidar": "1.7.0",
         "commander": "2.11.0",
         "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
+        "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "output-file-sync": "1.1.2",
@@ -444,16 +443,16 @@
       "integrity": "sha512-yyl5U088oE+419+BNLJDKVWkUokuPLQeQt9ZTy9uM9kAzbtQgyYL3JkG425B8jxXA7MwTxnDAtRLMKJNH36qjA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.31",
-        "@babel/traverse": "7.0.0-beta.31",
-        "@babel/types": "7.0.0-beta.31",
-        "babylon": "7.0.0-beta.31"
+        "@babel/code-frame": "7.0.0-beta.32",
+        "@babel/traverse": "7.0.0-beta.32",
+        "@babel/types": "7.0.0-beta.32",
+        "babylon": "7.0.0-beta.32"
       },
       "dependencies": {
         "babylon": {
-          "version": "7.0.0-beta.31",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
-          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "version": "7.0.0-beta.32",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.32.tgz",
+          "integrity": "sha512-PvAmyP2IJEBVAuE5yVzrTSWCCN9VMa1eGns8w3w6FYD/ivHSUmS7n+F40Fmjn+0nCQSUFR96wP0CqQ4jxTnF4Q==",
           "dev": true
         }
       }
@@ -1122,12 +1121,6 @@
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -1169,7 +1162,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.8.0",
+        "browserslist": "2.9.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1235,14 +1228,6 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -1252,13 +1237,6 @@
       "requires": {
         "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
-        }
       }
     },
     "babel-template": {
@@ -1359,9 +1337,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true,
       "optional": true
     },
@@ -1486,12 +1464,12 @@
       }
     },
     "browserslist": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.8.0.tgz",
-      "integrity": "sha512-iiWHM1Et6Q4TQpB7Ar6pxuM3TNMXasVJY4Y/oh3q38EwR3Z+IdZ9MyVf7PI4MJFB4xpwMcZgs9bEUnPG2E3TCA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.0.tgz",
+      "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000760",
+        "caniuse-lite": "1.0.30000769",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -1550,9 +1528,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000760",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz",
-      "integrity": "sha1-7HIDlXQvHH7IlH/W3SYE53qPmP8=",
+      "version": "1.0.30000769",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000769.tgz",
+      "integrity": "sha1-1oxaoHcuo+rGyX1C4jnJtNMmG5M=",
       "dev": true
     },
     "caseless": {
@@ -1590,6 +1568,12 @@
           "dev": true
         }
       }
+    },
+    "chardet": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.0.tgz",
+      "integrity": "sha1-C74TVaxE16PtSpJXB8TvcPgZD2w=",
+      "dev": true
     },
     "cheerio": {
       "version": "0.19.0",
@@ -1773,9 +1757,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2147,12 +2131,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.10.0.tgz",
-      "integrity": "sha512-MMVl8P/dYUFZEvolL8PYt7qc5LNdS2lwheq9BYa5Y07FblhcZqFyaUqlS8TW5QITGex21tV4Lk0a3fK8lsJIkA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.11.0.tgz",
+      "integrity": "sha512-UWbhQpaKlm8h5x/VLwm0S1kheMrDj8jPwhnBMjr/Dlo3qqT7MvcN/UfKAR3E1N4lr4YNtOvS4m3hwsrVc/ky7g==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.4.0",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.0",
         "concat-stream": "1.6.0",
@@ -2160,7 +2144,7 @@
         "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
+        "espree": "3.5.2",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -2173,7 +2157,7 @@
         "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -2253,9 +2237,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.7.0.tgz",
-      "integrity": "sha1-e7/vZq14MneDb06lVuaLm8ydpNA=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.8.0.tgz",
+      "integrity": "sha512-XuCvdsC+n4jYPXxEyleaTF9wQR/rv5ofbrhTJiVAv+a91O9EcroicK74XHtbAYeopkF7i2EAH2GNLU48PnRIqw==",
       "dev": true,
       "requires": {
         "get-stdin": "5.0.1"
@@ -2378,9 +2362,9 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz",
-      "integrity": "sha512-tvjU9u3VqmW2vVuYnE8Qptq+6ji4JltjOjJ9u7VAOxVYkUkyBZWRvNYKbDv5fN+L6wiA+4we9+qQahZ0m63XEA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz",
+      "integrity": "sha512-YGSjB9Qu6QbVTroUZi66pYky3DfoIPLdHQ/wmrBGyBRnwxQsBXAov9j2rpXt/55i8nyMv6IRWJv2s4d4YnduzQ==",
       "dev": true,
       "requires": {
         "doctrine": "2.0.0",
@@ -2406,9 +2390,9 @@
       }
     },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -2447,9 +2431,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.0.tgz",
-      "integrity": "sha512-/bEAy+yKAZQrEWUhGmS3H9XpGqSDBtRzX0I2PgMw9kA2n1jN22uV5B5p7MFdZdvWdXCRJztXAfx6ZeRfgkEETg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+      "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
       "dev": true
     },
     "esutils": {
@@ -2504,13 +2488,13 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
+        "chardet": "0.4.0",
         "iconv-lite": "0.4.19",
-        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       }
     },
@@ -2565,6 +2549,13 @@
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        }
       }
     },
     "figures": {
@@ -2704,20 +2695,20 @@
       }
     },
     "fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
+        "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       }
     },
     "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -2733,7 +2724,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
+        "nan": "2.8.0",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -3707,6 +3698,28 @@
         }
       }
     },
+    "get-image-colors": {
+      "version": "github:ChristophLabacher/get-image-colors#15a4c08f06be243d4cd5804888346dc09a0239ea",
+      "dev": true,
+      "requires": {
+        "chroma-js": "1.3.4",
+        "get-pixels": "3.3.0",
+        "get-rgba-palette": "2.0.1",
+        "get-svg-colors": "1.4.0",
+        "tmp": "0.0.28"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        }
+      }
+    },
     "get-pixels": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/get-pixels/-/get-pixels-3.3.0.tgz",
@@ -3748,9 +3761,9 @@
       "dev": true
     },
     "get-svg-colors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-svg-colors/-/get-svg-colors-1.3.0.tgz",
-      "integrity": "sha1-7LxtTsTYOwWfHs9no91ltI/AqYk=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-svg-colors/-/get-svg-colors-1.4.0.tgz",
+      "integrity": "sha512-7AOzW0XUgNG8hy9OdJV6AbojstBn0R2WoB0Nzudro80JQXo6rVzxJgkaLc70qaXazv+NC8o0OvLfk3nll2zxAw==",
       "dev": true,
       "requires": {
         "cheerio": "0.19.0",
@@ -3770,29 +3783,20 @@
       }
     },
     "gh-pages": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.0.0.tgz",
-      "integrity": "sha1-Skb0wlQ596K35oNVBNSknpSfBMo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.1.0.tgz",
+      "integrity": "sha512-ZpDkeOVmIrN5mz+sBWDz5zmTqcbNJzI/updCwEv/7rrSdpTNlj1B5GhBqG7f4Q8p5sJOdnBV0SIqxJrxtZQ9FA==",
       "dev": true,
       "requires": {
-        "async": "2.1.4",
+        "async": "2.6.0",
         "base64url": "2.0.0",
-        "commander": "2.9.0",
-        "fs-extra": "3.0.1",
+        "commander": "2.11.0",
+        "fs-extra": "4.0.2",
         "globby": "6.1.0",
         "graceful-fs": "4.1.11",
         "rimraf": "2.6.2"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -3894,12 +3898,6 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "gzip-size": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
@@ -3921,7 +3919,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.4.0",
         "har-schema": "2.0.0"
       }
     },
@@ -4120,7 +4118,7 @@
         "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -4218,7 +4216,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -4470,7 +4468,7 @@
         "mime": "1.4.1",
         "mkdirp": "0.5.1",
         "pixelmatch": "4.0.2",
-        "pngjs": "3.3.0",
+        "pngjs": "3.3.1",
         "read-chunk": "1.0.1",
         "request": "2.83.0",
         "stream-to-buffer": "0.1.0",
@@ -4485,9 +4483,9 @@
           "dev": true
         },
         "pngjs": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.0.tgz",
-          "integrity": "sha1-H1cwwYnJSTO4G+2iqy+OKFUmOo8=",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
+          "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg==",
           "dev": true
         }
       }
@@ -4520,12 +4518,6 @@
       "dev": true,
       "optional": true
     },
-    "jschardet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
-      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
-      "dev": true
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -4549,9 +4541,16 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4566,9 +4565,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
@@ -4578,7 +4577,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4953,9 +4953,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true
     },
     "natural-compare": {
@@ -5200,7 +5200,7 @@
       "requires": {
         "commander": "2.11.0",
         "defaults": "1.0.3",
-        "nan": "2.7.0",
+        "nan": "2.8.0",
         "node-pre-gyp": "0.6.39"
       }
     },
@@ -5350,28 +5350,6 @@
         "gonzales-pe": "3.4.7",
         "node-vibrant": "2.1.2",
         "opencolor": "0.2.0"
-      },
-      "dependencies": {
-        "get-image-colors": {
-          "version": "github:ChristophLabacher/get-image-colors#15a4c08f06be243d4cd5804888346dc09a0239ea",
-          "dev": true,
-          "requires": {
-            "chroma-js": "1.3.4",
-            "get-pixels": "3.3.0",
-            "get-rgba-palette": "2.0.1",
-            "get-svg-colors": "1.3.0",
-            "tmp": "0.0.28"
-          }
-        },
-        "tmp": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
-        }
       }
     },
     "optionator": {
@@ -5579,13 +5557,13 @@
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "dev": true,
       "requires": {
-        "pngjs": "3.3.0"
+        "pngjs": "3.3.1"
       },
       "dependencies": {
         "pngjs": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.0.tgz",
-          "integrity": "sha1-H1cwwYnJSTO4G+2iqy+OKFUmOo8=",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
+          "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg==",
           "dev": true
         }
       }
@@ -6190,9 +6168,9 @@
       }
     },
     "rollup": {
-      "version": "0.51.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.51.5.tgz",
-      "integrity": "sha512-nvwUduO53TvWigOaOv7t+rNoEUW53sTUeqMAjlxp7ekeHirPECnWXSwiPwiqvGNdbJTQbOdHFPAZZfjo61BtVQ==",
+      "version": "0.51.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.51.8.tgz",
+      "integrity": "sha512-e7FwWxqb4vhdonmwRH06nqC9wR6h1kZojK2D+lN1xjiB8FDtAKgy7o+r8fCXVzQZ1ZCdcVlls3mTq5g6u38Jew==",
       "dev": true
     },
     "rollup-plugin-babel": {
@@ -6202,24 +6180,6 @@
       "dev": true,
       "requires": {
         "rollup-pluginutils": "1.5.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-          "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
-          "dev": true
-        },
-        "rollup-pluginutils": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
-          "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
-          "dev": true,
-          "requires": {
-            "estree-walker": "0.2.1",
-            "minimatch": "3.0.4"
-          }
-        }
       }
     },
     "rollup-plugin-commonjs": {
@@ -6233,12 +6193,38 @@
         "magic-string": "0.22.4",
         "resolve": "1.5.0",
         "rollup-pluginutils": "2.0.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.0.tgz",
+          "integrity": "sha512-/bEAy+yKAZQrEWUhGmS3H9XpGqSDBtRzX0I2PgMw9kA2n1jN22uV5B5p7MFdZdvWdXCRJztXAfx6ZeRfgkEETg==",
+          "dev": true
+        },
+        "rollup-pluginutils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+          "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+          "dev": true,
+          "requires": {
+            "estree-walker": "0.3.1",
+            "micromatch": "2.3.11"
+          },
+          "dependencies": {
+            "estree-walker": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+              "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "rollup-plugin-filesize": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-1.4.2.tgz",
-      "integrity": "sha1-7r31cSF+L+FKsUplNL8h93GgU7E=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-filesize/-/rollup-plugin-filesize-1.5.0.tgz",
+      "integrity": "sha512-J5Ja0xgba4YqWthoui95TlLJLgcheh78vB0SXJTEyB2AfhspJEN6wFJHFzRStVYPtD0zIyg6A5H+2UhaX5bVcw==",
       "dev": true,
       "requires": {
         "boxen": "1.2.2",
@@ -6277,24 +6263,6 @@
       "requires": {
         "chalk": "1.1.3",
         "rollup-pluginutils": "1.5.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
-          "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
-          "dev": true
-        },
-        "rollup-pluginutils": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
-          "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
-          "dev": true,
-          "requires": {
-            "estree-walker": "0.2.1",
-            "minimatch": "3.0.4"
-          }
-        }
       }
     },
     "rollup-plugin-rebase": {
@@ -6316,24 +6284,20 @@
         "sugarss": "1.0.1"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
+        "estree-walker": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+          "dev": true
         },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+        "rollup-pluginutils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+          "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "estree-walker": "0.3.1",
+            "micromatch": "2.3.11"
           }
         }
       }
@@ -6344,7 +6308,7 @@
       "integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
       "dev": true,
       "requires": {
-        "uglify-js": "3.1.9"
+        "uglify-js": "3.1.10"
       }
     },
     "rollup-plugin-url": {
@@ -6355,16 +6319,6 @@
       "requires": {
         "mime": "1.4.1",
         "rollup-pluginutils": "2.0.1"
-      }
-    },
-    "rollup-pluginutils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
-      "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
-      "dev": true,
-      "requires": {
-        "estree-walker": "0.3.1",
-        "micromatch": "2.3.11"
       },
       "dependencies": {
         "estree-walker": {
@@ -6372,7 +6326,27 @@
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
           "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
           "dev": true
+        },
+        "rollup-pluginutils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+          "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+          "dev": true,
+          "requires": {
+            "estree-walker": "0.3.1",
+            "micromatch": "2.3.11"
+          }
         }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+      "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+      "dev": true,
+      "requires": {
+        "estree-walker": "0.2.1",
+        "minimatch": "3.0.4"
       }
     },
     "run-async": {
@@ -6635,14 +6609,14 @@
         "is-function": "1.0.1",
         "is-plain-object": "2.0.4",
         "prop-types": "15.6.0",
-        "stylis": "3.4.0",
+        "stylis": "3.4.3",
         "supports-color": "3.2.3"
       }
     },
     "stylis": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.0.tgz",
-      "integrity": "sha512-RGVodOGadOR9RzRcZ+zzXXWMfuSmrQubeYtnzJZqq3jXIEH8zZ6nRRlOccn0RRsd19yUfYqtlvrq+SkNwfUH3A=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.3.tgz",
+      "integrity": "sha512-ScmjgdIRsLVh6haWj5mmmKXW1vjWBdXUDOqDfcEBn5Pfm/TqW9rfVUk2kJUKGL43+7Opot5vWAJxV6oXLbU3yA=="
     },
     "sugarss": {
       "version": "1.0.1",
@@ -6667,7 +6641,7 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.3.0",
+        "ajv": "5.4.0",
         "ajv-keywords": "2.1.1",
         "chalk": "2.3.0",
         "lodash": "4.17.4",
@@ -6852,9 +6826,9 @@
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
     },
     "uglify-js": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.9.tgz",
-      "integrity": "sha512-ari2E89bD7f+fMU173NgF12JBcOhgoxeyuCs97h5K58IBENrnG9eVj2lFadrOPdqf0KifsxVmUQfzA2cHNxCZQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.10.tgz",
+      "integrity": "sha512-0ul3BWx79We0mIPM1l72oqpMtWL0TVMnKZZY6FaHPy3tDzCZGXeFxw5N1ZvtkmQsLI+ECR/tUQyIYbyHUcuvEw==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
@@ -7115,7 +7089,7 @@
       "integrity": "sha1-i4pIFiz8zCG5IPpQAmEYfUAhbDk=",
       "dev": true,
       "requires": {
-        "nan": "2.7.0"
+        "nan": "2.8.0"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "react-motion": "^0.5.2",
     "react-onclickout": "^2.0.8",
     "react-responsive": "^3.0.0",
-    "styled-components": "^2.2.1"
+    "styled-components": "^2.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "babel-plugin-external-helpers": "^6.22.0",
+    "prop-types": "^15.6.0",
     "react-motion": "^0.5.2",
     "react-onclickout": "^2.0.8",
     "react-responsive": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,8 +15,7 @@ export default {
   plugins: [
     progress(),
     url({
-      // limit: 10 * 1024, // 10k
-      limit: false,
+      limit: 5 * 1024, // inline files smaller than 5k
       publicPath: '',
       include: [
         '**/*.svg',

--- a/src/components/AragonApp/AragonApp.js
+++ b/src/components/AragonApp/AragonApp.js
@@ -1,8 +1,10 @@
 /* @flow */
 import type { Node } from 'react'
 import React from 'react'
-import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
 import { BaseStyles, theme } from '../..'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import logo from './assets/logo-background.svg'
 
 // AragonApp provides everything needed to start an Aragon App.
@@ -12,7 +14,7 @@ const StyledAragonApp = styled.main`
   min-height: 100vh;
   background-color: ${theme.mainBackground};
   background-image: ${({ backgroundLogo }) =>
-    backgroundLogo ? `url(${logo})` : 'none'};
+    backgroundLogo ? css`url(${asset(logo)})` : 'none'};
   background-position: 50% 50%;
   background-repeat: no-repeat;
 `
@@ -20,6 +22,7 @@ const StyledAragonApp = styled.main`
 type Props = {
   className: string,
   backgroundLogo: boolean,
+  publicUrl: string,
   children: Node,
 }
 
@@ -27,11 +30,20 @@ class AragonApp extends React.Component<Props> {
   static defaultProps = {
     backgroundLogo: false,
   }
+  static childContextTypes = {
+    publicUrl: PropTypes.string,
+  }
   static Styled = StyledAragonApp
+
+  getChildContext() {
+    return { publicUrl: this.props.publicUrl }
+  }
+
   render() {
-    const { children, backgroundLogo, className } = this.props
+    const { children, backgroundLogo, className, publicUrl } = this.props
+    const styledProps = { backgroundLogo, className, publicUrl }
     return (
-      <StyledAragonApp {...{ backgroundLogo, className }}>
+      <StyledAragonApp {...styledProps}>
         <BaseStyles />
         {children}
       </StyledAragonApp>

--- a/src/components/BaseStyles/BaseStyles.js
+++ b/src/components/BaseStyles/BaseStyles.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { injectGlobal } from 'styled-components'
 import theme from '../../theme'
+import getPublicUrl from '../../public-url'
 
 import overpassLightWoff from './assets/overpass/overpass-light.woff'
 import overpassLightWoff2 from './assets/overpass/overpass-light.woff2'
@@ -10,25 +11,25 @@ import overpassRegularWoff2 from './assets/overpass/overpass-regular.woff2'
 import overpassSemiBoldWoff from './assets/overpass/overpass-semibold.woff'
 import overpassSemiBoldWoff2 from './assets/overpass/overpass-semibold.woff2'
 
-const injectStyles = () => injectGlobal`
+const injectStyles = asset => injectGlobal`
   @font-face {
     font-family: 'overpass';
-    src: url(${overpassLightWoff2}) format('woff2'),
-         url(${overpassLightWoff}) format('woff');
+    src: url(${asset(overpassLightWoff2)}) format('woff2'),
+         url(${asset(overpassLightWoff)}) format('woff');
     font-weight: 400;
     font-style: normal;
   }
   @font-face {
     font-family: 'overpass';
-    src: url(${overpassRegularWoff2}) format('woff2'),
-         url(${overpassRegularWoff}) format('woff');
+    src: url(${asset(overpassRegularWoff2)}) format('woff2'),
+         url(${asset(overpassRegularWoff)}) format('woff');
     font-weight: 600;
     font-style: normal;
   }
   @font-face {
     font-family: 'overpass';
-    src: url(${overpassSemiBoldWoff2}) format('woff2'),
-         url(${overpassSemiBoldWoff}) format('woff');
+    src: url(${asset(overpassSemiBoldWoff2)}) format('woff2'),
+         url(${asset(overpassSemiBoldWoff)}) format('woff');
     font-weight: 800;
     font-style: normal;
   }
@@ -90,11 +91,11 @@ type Props = {}
 
 class BaseStyles extends React.Component<Props> {
   componentWillMount() {
-    injectStyles()
+    injectStyles(url => this.props.publicUrl + url)
   }
   render() {
     return null
   }
 }
 
-export default BaseStyles
+export default getPublicUrl(BaseStyles)

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -3,6 +3,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import theme from '../../theme'
 import { fontStyle } from '../../shared-styles'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import cross from './assets/cross.svg'
 import check from './assets/check.svg'
 
@@ -93,19 +94,21 @@ const modeText = css`
   }
 `
 
-const compactStyle = css`padding: 5px 15px;`
+const compactStyle = css`
+  padding: 5px 15px;
+`
 
 const positiveStyle = css`
   padding-left: 34px;
-  background: url(${check}) no-repeat 12px calc(50% - 1px);
+  background: url(${asset(check)}) no-repeat 12px calc(50% - 1px);
 `
 
 const negativeStyle = css`
   padding-left: 30px;
-  background: url(${cross}) no-repeat 10px calc(50% - 1px);
+  background: url(${asset(cross)}) no-repeat 10px calc(50% - 1px);
 `
 
-const StyledButton = styled.button`
+const StyledButton = getPublicUrl(styled.button`
   width: ${({ wide }) => (wide ? '100%' : 'auto')};
   padding: 10px 15px;
   white-space: nowrap;
@@ -140,7 +143,7 @@ const StyledButton = styled.button`
     if (emphasis === 'negative') return negativeStyle
     return ''
   }};
-`
+`)
 
 export { StyledButton }
 export default StyledButton

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -6,6 +6,7 @@ import ClickOutHandler from 'react-onclickout'
 import theme from '../../theme'
 import { springConf } from '../../shared-styles'
 import { lerp } from '../../math-utils'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import DropDownItem from './DropDownItem'
 import arrow from './assets/arrow-down.svg'
 
@@ -42,9 +43,9 @@ const DropDownItems = styled.ul`
   list-style: none;
 `
 
-const DropDownActiveItem = styled(DropDownItem)`
+const DropDownActiveItem = getPublicUrl(styled(DropDownItem)`
   padding-right: 40px;
-  background: ${contentBackground} url(${arrow}) no-repeat calc(100% - 15px) 50%;
+  background: ${contentBackground} url(${asset(arrow)}) no-repeat calc(100% - 15px) 50%;
   border: 1px solid ${contentBorder};
   border-radius: 3px;
   &:hover,
@@ -54,7 +55,7 @@ const DropDownActiveItem = styled(DropDownItem)`
   &:active {
     color: ${textPrimary};
   }
-`
+`)
 
 type Props = {
   items: Array<string>,

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { colors, font, themeDark, breakpoint, grid } from '../..'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 
 import logo from './assets/logo.svg'
 import iconTwitter from './assets/twitter.svg'
@@ -12,7 +13,7 @@ import iconMail from './assets/mail.svg'
 const medium = css => breakpoint('medium', css)
 const large = css => breakpoint('large', css)
 
-const StyledFooter = styled.footer`
+const StyledFooter = getPublicUrl(styled.footer`
   padding: 60px 20px 10px;
   font-size: 15px;
   color: grey;
@@ -72,16 +73,16 @@ const StyledFooter = styled.footer`
     font-weight: 400;
   }
   .icon.twitter {
-    background-image: url(${iconTwitter});
+    background-image: url(${asset(iconTwitter)});
   }
   .icon.medium {
-    background-image: url(${iconMedium});
+    background-image: url(${asset(iconMedium)});
   }
   .icon.slack {
-    background-image: url(${iconSlack});
+    background-image: url(${asset(iconSlack)});
   }
   .icon.mail {
-    background-image: url(${iconMail});
+    background-image: url(${asset(iconMail)});
   }
 
   ${medium(`
@@ -134,7 +135,7 @@ const StyledFooter = styled.footer`
       line-height: 1.5;
     }
   `)};
-`
+`)
 
 type Props = {
   compact: boolean,
@@ -144,11 +145,11 @@ const DefaultProps = {
   compact: false,
 }
 
-const Footer = ({ compact }: Props) => (
+const Footer = ({ compact, publicUrl }: Props) => (
   <StyledFooter compact={compact}>
     <div className="main">
       <div className="logo">
-        <img src={logo} width="158" height="50" alt="Aragon" />
+        <img src={publicUrl + logo} width="158" height="50" alt="Aragon" />
       </div>
       <div className="all-links">
         {!compact && (
@@ -218,4 +219,4 @@ const Footer = ({ compact }: Props) => (
 
 Footer.defaultProps = DefaultProps
 
-export default Footer
+export default getPublicUrl(Footer)

--- a/src/components/Header/Logo.js
+++ b/src/components/Header/Logo.js
@@ -1,11 +1,12 @@
 /* @flow */
 import React from 'react'
 import styled from 'styled-components'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
+import { BreakPoint } from '../..'
+
 import logo from './assets/logo.svg'
 import logoCompact from './assets/logo-compact.svg'
 import logoMinimal from './assets/logo-minimal.svg'
-
-import { BreakPoint } from '../..'
 
 const Container = styled.span`
   display: flex;
@@ -15,6 +16,7 @@ const Container = styled.span`
 type Props = {
   compact: boolean,
   renderLink: mixed,
+  publicUrl: string,
 }
 
 const DefaultProps = {
@@ -22,7 +24,7 @@ const DefaultProps = {
   renderLink: ({ url, children }) => <a href={url}>{children}</a>,
 }
 
-const Logo = ({ compact, renderLink }: Props) => {
+const Logo = ({ compact, renderLink, publicUrl }: Props) => {
   return (
     <span className="logo">
       {renderLink({
@@ -30,15 +32,15 @@ const Logo = ({ compact, renderLink }: Props) => {
         children: (
           <Container>
             <BreakPoint to="medium">
-              <img alt="Aragon" src={logoMinimal} height={40} />
+              <img alt="Aragon" src={publicUrl + logoMinimal} height={40} />
             </BreakPoint>
             <BreakPoint from="medium" to="large">
-              <img alt="Aragon" src={logoMinimal} height={50} />
+              <img alt="Aragon" src={publicUrl + logoMinimal} height={50} />
             </BreakPoint>
             <BreakPoint from="large">
               <img
                 alt="Aragon"
-                src={compact ? logoCompact : logo}
+                src={publicUrl + (compact ? logoCompact : logo)}
                 height={compact ? 36 : 51}
               />
             </BreakPoint>
@@ -51,4 +53,4 @@ const Logo = ({ compact, renderLink }: Props) => {
 
 Logo.defaultProps = DefaultProps
 
-export default Logo
+export default getPublicUrl(Logo)

--- a/src/components/Header/MenuPanel.js
+++ b/src/components/Header/MenuPanel.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Motion, spring } from 'react-motion'
 import ClickOutHandler from 'react-onclickout'
 import { spring as springConf, unselectable } from '../../shared-styles'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import theme from '../../theme'
 
 import close from './assets/close.svg'
@@ -60,7 +61,7 @@ class Panel extends React.Component {
     this.setState({ opened: false })
   }
   render() {
-    const { items, renderLink = renderLinkDefault } = this.props
+    const { items, publicUrl, renderLink = renderLinkDefault } = this.props
     const { opened } = this.state
     return (
       <Motion
@@ -72,11 +73,11 @@ class Panel extends React.Component {
           <Container>
             <ClickOutHandler onClickOut={this.close}>
               <Toggle onClick={this.toggle}>
-                <img src={opened ? close : menu} alt="" />
+                <img src={publicUrl + (opened ? close : menu)} alt="" />
               </Toggle>
               <PanelStyles
                 style={{
-                  display: openProgress > 0? 'block' : 'none',
+                  display: openProgress > 0 ? 'block' : 'none',
                   opacity: openProgress,
                   transform: `translateY(-${(1 - openProgress) * 5}px)`,
                 }}
@@ -100,4 +101,4 @@ class Panel extends React.Component {
   }
 }
 
-export default Panel
+export default getPublicUrl(Panel)

--- a/src/components/PreFooter/PreFooter.js
+++ b/src/components/PreFooter/PreFooter.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { Section, Button, grid, colors, themeDark, breakpoint } from '../..'
+import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 
 import logo from './assets/logo.svg'
 import bgLandscape from './assets/bg-landscape.svg'
@@ -10,18 +11,22 @@ import bgPortrait from './assets/bg-portrait.svg'
 const medium = css => breakpoint('medium', css)
 const large = css => breakpoint('large', css)
 
-const Main = styled.div`
+const Main = getPublicUrl(styled.div`
   position: relative;
   overflow: hidden;
   background-color: ${colors.Rain.Shark};
   background-repeat: no-repeat;
   background-position: 50% 50%;
   background-size: cover;
-  background-image: url(${bgPortrait});
-  ${large(`background-image: url(${bgLandscape})`)};
-`
+  background-image: url(${asset(bgPortrait)});
+  ${large(
+    css`
+      background-image: url(${asset(bgLandscape)});
+    `
+  )};
+`)
 
-const Container = styled(Section).attrs({ visual: true })`
+const Container = getPublicUrl(styled(Section).attrs({ visual: true })`
   position: relative;
   z-index: 2;
   padding: 0 20px;
@@ -32,7 +37,7 @@ const Container = styled(Section).attrs({ visual: true })`
     flex-direction: column;
     align-items: center;
     width: 100%;
-    background: url(${logo}) no-repeat 50% 50%;
+    background: url(${asset(logo)}) no-repeat 50% 50%;
     background-size: 140px;
     ${large(`background-size: 200px;`)};
   }
@@ -94,7 +99,7 @@ const Container = styled(Section).attrs({ visual: true })`
       padding-bottom: 0;
     }
   `)};
-`
+`)
 
 const PreFooter = () => (
   <Main>

--- a/src/components/PreFooter/PreFooter.js
+++ b/src/components/PreFooter/PreFooter.js
@@ -19,11 +19,7 @@ const Main = getPublicUrl(styled.div`
   background-position: 50% 50%;
   background-size: cover;
   background-image: url(${asset(bgPortrait)});
-  ${large(
-    css`
-      background-image: url(${asset(bgLandscape)});
-    `
-  )};
+  ${large(css`background-image: url(${asset(bgLandscape)})`)};
 `)
 
 const Container = getPublicUrl(styled(Section).attrs({ visual: true })`

--- a/src/components/Section/Section.js
+++ b/src/components/Section/Section.js
@@ -12,6 +12,7 @@ const StyledContent = styled.div`
 `
 
 type Props = {
+  publicUrl: string,
   large: boolean,
   visual: boolean,
 }
@@ -21,7 +22,7 @@ const DefaultProps = {
   visual: false,
 }
 
-const Section = ({ large, visual, className, ...props }: Props) => {
+const Section = ({ large, visual, className, publicUrl, ...props }: Props) => {
   const containerProps = { className }
   const content = (
     <StyledContent large={large}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,14 @@
+export {
+  css as styledCss,
+  keyframes as styledKeyframes,
+  injectGlobal as styledInjectGlobal,
+  ThemeProvider as styledThemeProvider,
+  withTheme as styledWithTheme,
+  ServerStyleSheet as styledServerStyleSheet,
+  StyleSheetManager as styledStyleSheetManager,
+  default as styled,
+} from 'styled-components'
+
 export { default as theme, themeDark, brand, colors } from './theme'
 export { font, grid, spring, breakpoint, unselectable, BreakPoint } from './shared-styles'
 export { default as BaseStyles } from './components/BaseStyles/BaseStyles'

--- a/src/public-url.js
+++ b/src/public-url.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// High order component wrapper
+const getPublicUrl = Component => {
+  const highOrderComponent = (baseProps, context) => {
+    const { publicUrl = '' } = context
+    const props = { ...baseProps, publicUrl }
+    return <Component {...props} />
+  }
+  highOrderComponent.contextTypes = {
+    publicUrl: PropTypes.string,
+  }
+  return highOrderComponent
+}
+
+// styled-component helper
+const styledPublicUrl = url => ({ publicUrl }) =>
+  url.startsWith('data:') ? url : publicUrl + url
+
+export { styledPublicUrl }
+export default getPublicUrl

--- a/src/shared-styles.js
+++ b/src/shared-styles.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Responsive from 'react-responsive'
+import { css } from 'styled-components'
 
 const FONT_SIZES = {
   xsmall: '12px',
@@ -52,9 +53,9 @@ export const spring = name => {
 }
 
 // CSS breakpoints
-export const breakpoint = (name, css) => `
+export const breakpoint = (name, styles) => css`
   @media (min-width: ${BREAKPOINTS[name]}px) {
-    ${css}
+    ${styles};
   }
 `
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,54 +2,53 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.31", "@babel/code-frame@^7.0.0-beta.31":
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz#473d021ecc573a2cce1c07d5b509d5215f46ba35"
+"@babel/code-frame@7.0.0-beta.32", "@babel/code-frame@^7.0.0-beta.31":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.32.tgz#04f231b8ec70370df830d9926ce0f5add074ec4c"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/helper-function-name@7.0.0-beta.31":
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz#afe63ad799209989348b1109b44feb66aa245f57"
+"@babel/helper-function-name@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.32.tgz#6161af4419f1b4e3ed2d28c0c79c160e218be1f3"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.31"
-    "@babel/template" "7.0.0-beta.31"
-    "@babel/traverse" "7.0.0-beta.31"
-    "@babel/types" "7.0.0-beta.31"
+    "@babel/helper-get-function-arity" "7.0.0-beta.32"
+    "@babel/template" "7.0.0-beta.32"
+    "@babel/types" "7.0.0-beta.32"
 
-"@babel/helper-get-function-arity@7.0.0-beta.31":
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz#1176d79252741218e0aec872ada07efb2b37a493"
+"@babel/helper-get-function-arity@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.32.tgz#93721a99db3757de575a83bab7c453299abca568"
   dependencies:
-    "@babel/types" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.32"
 
-"@babel/template@7.0.0-beta.31":
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.31.tgz#577bb29389f6c497c3e7d014617e7d6713f68bda"
+"@babel/template@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.32.tgz#e1d9fdbd2a7bcf128f2f920744a67dab18072495"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.31"
-    "@babel/types" "7.0.0-beta.31"
-    babylon "7.0.0-beta.31"
+    "@babel/code-frame" "7.0.0-beta.32"
+    "@babel/types" "7.0.0-beta.32"
+    babylon "7.0.0-beta.32"
     lodash "^4.2.0"
 
-"@babel/traverse@7.0.0-beta.31", "@babel/traverse@^7.0.0-beta.31":
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.31.tgz#db399499ad74aefda014f0c10321ab255134b1df"
+"@babel/traverse@^7.0.0-beta.31":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.32.tgz#b78b754c6e1af3360626183738e4c7a05951bc99"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.31"
-    "@babel/helper-function-name" "7.0.0-beta.31"
-    "@babel/types" "7.0.0-beta.31"
-    babylon "7.0.0-beta.31"
+    "@babel/code-frame" "7.0.0-beta.32"
+    "@babel/helper-function-name" "7.0.0-beta.32"
+    "@babel/types" "7.0.0-beta.32"
+    babylon "7.0.0-beta.32"
     debug "^3.0.1"
     globals "^10.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-"@babel/types@7.0.0-beta.31", "@babel/types@^7.0.0-beta.31":
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.31.tgz#42c9c86784f674c173fb21882ca9643334029de4"
+"@babel/types@7.0.0-beta.32", "@babel/types@^7.0.0-beta.31":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.32.tgz#c317d0ecc89297b80bbcb2f50608e31f6452a5ff"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
@@ -69,7 +68,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.1.1, acorn@^5.2.1:
+acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
@@ -84,9 +83,9 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -207,9 +206,9 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
+async@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
 
@@ -891,9 +890,9 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.31, babylon@^7.0.0-beta.31:
-  version "7.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
+babylon@7.0.0-beta.32, babylon@^7.0.0-beta.31:
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.32.tgz#e9033cb077f64d6895f4125968b37dc0a8c3bc6e"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -926,8 +925,8 @@ bignumber.js@^2.1.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-2.4.0.tgz#838a992da9f9d737e0f4b2db0be62bb09dd0c5e8"
 
 binary-extensions@^1.0.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
 binary@^0.3.0:
   version "0.3.0"
@@ -1002,10 +1001,10 @@ browser-resolve@^1.11.0:
     resolve "1.1.7"
 
 browserslist@^2.1.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.8.0.tgz#27d64028130a2e8585ca96f7c3b7730eff4de493"
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.9.0.tgz#706aca15c53be15610f466e348cbfa0c00a6a379"
   dependencies:
-    caniuse-lite "^1.0.30000758"
+    caniuse-lite "^1.0.30000760"
     electron-to-chromium "^1.3.27"
 
 buffer-equal@0.0.1:
@@ -1045,9 +1044,9 @@ camelcase@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-caniuse-lite@^1.0.30000758:
-  version "1.0.30000760"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz#ec720395742f1c7ec8947fd6dd2604e77a8f98ff"
+caniuse-lite@^1.0.30000760:
+  version "1.0.30000769"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000769.tgz#d68c5aa0772ea3eac6c97d42e239c9b4d3261b93"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1076,6 +1075,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chardet@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.0.tgz#0bbe1355ac44d7a3ed4a925707c4ef70f8190f6c"
 
 cheerio@^0.19.0:
   version "0.19.0"
@@ -1170,13 +1173,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
-
-commander@^2.11.0, commander@^2.8.1, commander@~2.11.0:
+commander@2.11.0, commander@^2.11.0, commander@^2.8.1, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
@@ -1483,8 +1480,8 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 eslint-config-prettier@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.7.0.tgz#7bbfef66ad783277836f4ea556e68b9bcc9da4d0"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.8.0.tgz#929861a11de0249677686eba908118175d1a26bc"
   dependencies:
     get-stdin "^5.0.1"
 
@@ -1558,13 +1555,13 @@ eslint-plugin-promise@^3.6.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz#54b7658c8f454813dc2a870aff8152ec4969ba75"
 
 eslint-plugin-react@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz#300a95861b9729c087d362dd64abcc351a74364a"
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.5.1.tgz#52e56e8d80c810de158859ef07b880d2f56ee30b"
   dependencies:
     doctrine "^2.0.0"
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
-    prop-types "^15.5.10"
+    prop-types "^15.6.0"
 
 eslint-plugin-standard@^3.0.1:
   version "3.0.1"
@@ -1578,10 +1575,10 @@ eslint-scope@^3.7.1:
     estraverse "^4.1.1"
 
 eslint@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.10.0.tgz#f25d0d7955c81968c2309aa5c9a229e045176bb7"
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.11.0.tgz#39a8c82bc0a3783adf5a39fa27fdd9d36fac9a34"
   dependencies:
-    ajv "^5.2.0"
+    ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
@@ -1589,7 +1586,7 @@ eslint@^4.10.0:
     debug "^3.0.1"
     doctrine "^2.0.0"
     eslint-scope "^3.7.1"
-    espree "^3.5.1"
+    espree "^3.5.2"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
@@ -1602,7 +1599,7 @@ eslint@^4.10.0:
     inquirer "^3.0.6"
     is-resolvable "^1.0.0"
     js-yaml "^3.9.1"
-    json-stable-stringify "^1.0.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.4"
     minimatch "^3.0.2"
@@ -1619,11 +1616,11 @@ eslint@^4.10.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
+espree@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
-    acorn "^5.1.1"
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@^4.0.0:
@@ -1696,11 +1693,11 @@ extend@~3.0.0, extend@~3.0.1:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
 external-editor@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.5.tgz#52c249a3981b9ba187c7cacf5beb50bf1d91a6bc"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
   dependencies:
+    chardet "^0.4.0"
     iconv-lite "^0.4.17"
-    jschardet "^1.4.2"
     tmp "^0.0.33"
 
 extglob@^0.3.1:
@@ -1842,14 +1839,6 @@ form-data@~2.3.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-fs-extra@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
@@ -1859,19 +1848,19 @@ fs-extra@^4.0.2:
     universalify "^0.1.0"
 
 fs-readdir-recursive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.3.tgz#11f82318f5fe7bb2cd22965a108e9306208216d8"
   dependencies:
     nan "^2.3.0"
-    node-pre-gyp "^0.6.36"
+    node-pre-gyp "^0.6.39"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -1952,8 +1941,8 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 get-svg-colors@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-svg-colors/-/get-svg-colors-1.3.0.tgz#ecbc6d4ec4d83b059f1ecf67a3dd65b48fc0a989"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/get-svg-colors/-/get-svg-colors-1.4.0.tgz#308526948fb4b072e7cdd6b33a18d96cee171bac"
   dependencies:
     cheerio "^0.19.0"
     chroma-js "^1.1.1"
@@ -1968,16 +1957,16 @@ getpass@^0.1.1:
     assert-plus "^1.0.0"
 
 gh-pages@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-1.0.0.tgz#4a46f4c25439f7a2b7e6835504d4a49e949f04ca"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-1.1.0.tgz#738134d8e35e5323b39892cda28b8904e85f24b2"
   dependencies:
-    async "2.1.4"
+    async "2.6.0"
     base64url "^2.0.0"
-    commander "2.9.0"
-    fs-extra "^3.0.1"
+    commander "2.11.0"
+    fs-extra "^4.0.2"
     globby "^6.1.0"
     graceful-fs "4.1.11"
-    rimraf "^2.5.4"
+    rimraf "^2.6.2"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2011,8 +2000,8 @@ global@~4.3.0:
     process "~0.5.1"
 
 globals@^10.0.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-10.3.0.tgz#716aba93657b56630b5a0e77de5ea8ac6215afaa"
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
 
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
@@ -2054,10 +2043,6 @@ gonzales-pe@^4.0.3:
 graceful-fs@4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 gzip-size@^3.0.0:
   version "3.0.0"
@@ -2481,10 +2466,6 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jschardet@^1.4.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
-
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -2501,6 +2482,10 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
 json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
@@ -2514,12 +2499,6 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -2806,8 +2785,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.0.0, nan@^2.3.0, nan@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2844,7 +2823,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-pre-gyp@^0.6.36, node-pre-gyp@^0.6.4:
+node-pre-gyp@^0.6.39, node-pre-gyp@^0.6.4:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
   dependencies:
@@ -3151,8 +3130,8 @@ pngjs@^2.0.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-2.3.1.tgz#11d1e12b9cb64d63e30c143a330f4c1f567da85f"
 
 pngjs@^3.0.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.0.tgz#1f5730c189c94933b81beda2ab2f8e2855263a8f"
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.1.tgz#8e14e6679ee7424b544334c3b2d21cea6d8c209a"
 
 postcss-import@^11.0.0:
   version "11.0.0"
@@ -3234,7 +3213,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3511,7 +3490,7 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -3534,8 +3513,8 @@ rollup-plugin-commonjs@^8.2.6:
     rollup-pluginutils "^2.0.1"
 
 rollup-plugin-filesize@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-1.4.2.tgz#eebdf571217e2fe14ab14a6534bf21f771a053b1"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-1.5.0.tgz#bb5841242d88be57f231c9e8a3a541925392178b"
   dependencies:
     boxen "^1.1.0"
     colors "^1.1.2"
@@ -3609,8 +3588,8 @@ rollup-pluginutils@^2.0.1:
     micromatch "^2.3.11"
 
 rollup@^0.51.5:
-  version "0.51.5"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.51.5.tgz#5caf9101fcaefe344065701ece7de697631a8035"
+  version "0.51.8"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.51.8.tgz#58bd0b642885f4770b5f93cc64f14e4233c2236d"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -3801,7 +3780,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-components@^2.2.1:
+styled-components@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.2.3.tgz#154575c269880c840f903f580287dab155cf684c"
   dependencies:
@@ -3816,8 +3795,8 @@ styled-components@^2.2.1:
     supports-color "^3.2.3"
 
 stylis@3.x:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.0.tgz#55c6530ebceeca5976d54fb4adc67578afee828d"
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.3.tgz#875bd0db3db37bb6de08f89275fc38ee2e32ee75"
 
 sugarss@^1.0.0:
   version "1.0.1"
@@ -3958,8 +3937,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-js@^3.0.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.9.tgz#dffca799308cf327ec3ac77eeacb8e196ce3b452"
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.10.tgz#c4a5f9b5c6276b40cb971c1d97c9eeb26af9509c"
   dependencies:
     commander "~2.11.0"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,7 +3234,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:


### PR DESCRIPTION
There are two different ways to handle a library as a dependency:

- As a source library
- As a runtime library, transpiled to “universal JS”

The problem with the source is that it brings many problems to make it work with the parent app:

- Having to install the same dependencies in the parent project.
- Having to install the same build dependencies.
- Having to configure the build exactly the same way.
- Update these every time the library is updated.

Using the transpiled library solves all this problems, except one. Most modern build systems have some mechanism to import non-JS dependencies, which allows, in the context of a components library, to have the assets of a component in the same directory (instead of using a global folder).

When the modules are transpiled, the link between the importing module and the assets is lost in the process, and all the links to the assets are broken.

The solution implemented by this commit is the following:

- The library is transpiled to “universal JS”, with and without ES6 modules (for tree shaking, if the parent project build system supports it).
- The parent project imports the transpiled version of Aragon UI, and also copy the Aragon UI assets into a directory where they can be served by a web server.
- The parent project wraps the Aragon UI app into AragonApp, which allows to set the public URL of the toolkit assets: `<AragonApp publicUrl="/">`
- That way, each Aragon UI component using an asset is aware of the URL where they can be fetched from.
