### PR TITLE
Text: refactor to always render as <span>

### DIFF
--- a/gallery/src/pages/PageText.js
+++ b/gallery/src/pages/PageText.js
@@ -21,12 +21,12 @@ const PageText = ({ title }) => (
   <Page title={title} readme={readme}>
     <Page.Demo>
       <Container>
-        <Text size="xsmall">X-Small Text</Text>
-        <Text size="small">Small Text</Text>
-        <Text size="normal">Normal Text</Text>
-        <Text size="large">Large Text</Text>
-        <Text size="xlarge">X-Large Text</Text>
-        <Text size="xxlarge">XX-Large Text</Text>
+        <Text.Block size="xsmall">X-Small Text</Text.Block>
+        <Text.Block size="small">Small Text</Text.Block>
+        <Text.Block size="normal">Normal Text</Text.Block>
+        <Text.Block size="large">Large Text</Text.Block>
+        <Text.Block size="xlarge">X-Large Text</Text.Block>
+        <Text.Block size="xxlarge">XX-Large Text</Text.Block>
       </Container>
     </Page.Demo>
   </Page>

--- a/src/components/AragonApp/AppBar.js
+++ b/src/components/AragonApp/AppBar.js
@@ -4,7 +4,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import theme from '../../theme'
-import { StyledH1 } from '../Text/Text'
+import Text from '../Text/Text'
 
 import chevronSvg from './assets/chevron.svg'
 
@@ -27,7 +27,7 @@ const StyledAppBarEnd = styled.div`
   padding-right: 30px;
 `
 
-const StyledAppBarTitle = getPublicUrl(StyledH1.extend`
+const StyledAppBarTitle = getPublicUrl(styled.h1`
   padding-right: 20px;
   margin-right: 20px;
   background-image: ${({ chevron }) =>
@@ -45,8 +45,8 @@ type Props = {
 const AppBar = ({ children, endContent, title, ...props }: Props) => (
   <StyledAppBar {...props}>
     <StyledAppBarStart>
-      <StyledAppBarTitle chevron={!!children} size="xxlarge">
-        {title}
+      <StyledAppBarTitle chevron={!!children}>
+        <Text size="xxlarge">{title}</Text>
       </StyledAppBarTitle>
     </StyledAppBarStart>
     {children}

--- a/src/components/Card/EmptyStateCard.js
+++ b/src/components/Card/EmptyStateCard.js
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import theme from '../../theme'
 import Button from '../Button/Button'
-import Text, { StyledH1 } from '../Text/Text'
+import Text from '../Text/Text'
 import Card from './Card'
 
 const StyledCard = Card.extend`
@@ -16,7 +16,7 @@ const StyledCard = Card.extend`
   }
 `
 
-const StyledHeading = StyledH1.extend`
+const StyledHeading = styled.h1`
   margin: 20px 0 5px;
 `
 
@@ -48,10 +48,12 @@ const EmptyStateCard = ({
   <StyledCard {...props}>
     <section>
       <img src={icon} alt="" />
-      <StyledHeading color={theme.accent} weight="bold" size="large">
-        {title}
+      <StyledHeading>
+        <Text color={theme.accent} weight="bold" size="large">
+          {title}
+        </Text>
       </StyledHeading>
-      <Text>{text}</Text>
+      <Text.Block>{text}</Text.Block>
       <StyledActionButton mode="strong" onClick={onActivate}>
         {actionText}
       </StyledActionButton>

--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -17,9 +17,9 @@ type Props = {
 const Field = ({ children, label, ...props }: Props) => (
   <StyledField {...props}>
     <label>
-      <Text color={theme.textSecondary} smallcaps>
+      <Text.Block color={theme.textSecondary} smallcaps>
         {label}
-      </Text>
+      </Text.Block>
       {children}
     </label>
   </StyledField>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -112,9 +112,9 @@ const Header = ({ title, menuItems, renderMenuItemLink }: Props) => (
         <Logo compact={Boolean(title)} renderLink={renderMenuItemLink} />
         {title && (
           <div className="title">
-            <Text heading="1" size="xlarge">
-              {title}
-            </Text>
+            <h1>
+              <Text size="xlarge">{title} </Text>
+            </h1>
           </div>
         )}
         {menuItems.length > 0 && (

--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -91,9 +91,9 @@ const SidePanel = ({ children, title, opened, onClose, publicUrl }: Props) => {
             <Overlay style={styles.overlay} />
             <StyledPanel style={styles.panel}>
               <StyledPanelHeader>
-                <Text size="xxlarge" heading="1">
-                  {title}
-                </Text>
+                <h1>
+                  <Text size="xxlarge">{title}</Text>
+                </h1>
                 <StyledPanelCloseButton type="button" onClick={onClose}>
                   <img src={prefixUrl(close, publicUrl)} alt="Close" />
                 </StyledPanelCloseButton>

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -16,9 +16,9 @@ type Props = {
 
 const TableHeader = ({ title, ...props }: Props) => (
   <StyledTableHeader {...props}>
-    <Text color={theme.textSecondary} smallcaps>
+    <Text.Block color={theme.textSecondary} smallcaps>
       {title}
-    </Text>
+    </Text.Block>
   </StyledTableHeader>
 )
 

--- a/src/components/Text/README.md
+++ b/src/components/Text/README.md
@@ -1,6 +1,6 @@
 # Text
 
-The Text component is used to display text with some additional features.
+The Text component is used to display inline text with some additional features.
 
 It is generally not necessary to use `<Text>` with the default properties:
 `<BaseStyles>` sets this style to the HTML elements by default.
@@ -17,25 +17,6 @@ const App = () => (
 
 ## Properties
 
-### `block`
-
-- Type: `Boolean`
-- Default value: `false`
-
-Set this property to a `true` to render the text as a `<div>`. Useful to group
-more than a single paragraph. Takes priority over `inline`.
-
-```jsx
-<Text size='large' block>
-  <p>Some text</p>
-  <ul>
-    <li>Item</li>
-    <li>Item</li>
-  </ul>
-  <p>Some text</p>
-</Text>
-```
-
 ### `color`
 
 - Type: `String`
@@ -47,32 +28,12 @@ Set this property to a color value to change the text color.
 <Text color='tomato'>Text Example</Text>
 ```
 
-### `heading`
+### `size`
 
-- Type: `Number` or `String`
-- Default value: `undefined`
+- Type: one of `'xsmall'`, `'small'`, `'normal'`, `'large'`, `'xlarge'`,` 'xxlarge'`
+- Default value: `normal`
 
-Set this property to a number between `1` and `6` to render the text as a
-heading. It will be rendered as `<h1>` to `<h6>` HTML elements.
-
-```jsx
-<Text heading='1'>Example</Text>
-```
-
-### `inline`
-
-- Type: `Boolean`
-- Default value: `false`
-
-Set this property to a `true` to render the text as a `<span>`. Useful to use
-`<Text>` inside a parent that only allows [Phrasing Content](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content).
-
-```jsx
-<h1>
-  <span>Hello </span>
-  <Text size='xsmall'>World</Text>
-</h1>
-```
+Set this property to change the size of the text.
 
 ### `smallcaps`
 
@@ -84,3 +45,20 @@ Set this property to a `true` to render the text as small capitals.
 ```jsx
 <Text smallcaps>Title Example</Text>
 ```
+
+### `weight`
+
+- Type: one of `'normal'`, `'bold'`, `'bolder'`
+- Default value: `normal`
+
+Set this property to change the weight of the text.
+
+## Attached Components
+
+### `Block`
+
+A block of text, supporting the same [properties](#properties).
+
+### `Paragraph`
+
+A paragraph of text, supporting the same [properties](#properties).

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -1,11 +1,24 @@
 /* @flow */
-import type { Node } from 'react'
+import type { ComponentType, ElementType, Node } from 'react'
 import React from 'react'
 import styled from 'styled-components'
 import theme from '../../theme'
 import { fontStyle } from '../../shared-styles'
 
-const StyledText = styled.p`
+type Props = {
+  children?: Node,
+  color?: string,
+  size?: string,
+  smallcaps?: boolean,
+  weight?: string,
+}
+
+type TextComponentType = {
+  Block: ComponentType<Props>,
+  Paragraph: ComponentType<Props>,
+}
+
+const StyledText = styled.span`
   ${({ size, weight }) => fontStyle({ size, weight })};
   ${({ smallcaps }) => {
     if (!smallcaps) return ''
@@ -19,92 +32,35 @@ const StyledText = styled.p`
   }};
 `
 
-const StyledBlock = StyledText.withComponent('div')
-const StyledInline = StyledText.withComponent('span')
+const Text = props => <StyledText {...props} />
 
-const StyledH1 = StyledText.withComponent('h1')
-const StyledH2 = StyledText.withComponent('h2')
-const StyledH3 = StyledText.withComponent('h3')
-const StyledH4 = StyledText.withComponent('h4')
-const StyledH5 = StyledText.withComponent('h5')
-const StyledH6 = StyledText.withComponent('h6')
-const styledHeadings = [
-  StyledH1,
-  StyledH2,
-  StyledH3,
-  StyledH4,
-  StyledH5,
-  StyledH6,
-]
-
-const getStyledComponent = ({ heading, block = false, inline = false }) => {
-  if (block) return StyledBlock
-  if (inline) return StyledInline
-  if (heading) {
+const createTextContainer = (
+  Element: ElementType,
+  defaultProps?: Props
+): ComponentType<Props> => {
+  const Container = ({
+    children,
+    color,
+    size,
+    smallcaps,
+    weight,
+    ...props
+  }: Props) => {
+    const textProps = { color, size, smallcaps, weight }
     return (
-      styledHeadings[Math.max(1, Math.min(6, parseInt(heading, 10))) - 1] ||
-      StyledText
+      <Element {...props}>
+        <Text {...textProps}>{children}</Text>
+      </Element>
     )
   }
-  return StyledText
+  Container.defaultProps = defaultProps
+
+  return Container
 }
 
-type Props = {
-  block: boolean,
-  inline: boolean,
-  heading: string | number,
-  smallcaps: boolean,
-  size: string,
-  weight: string,
-  color: string,
-  children: Node,
-}
+Text.Block = createTextContainer('div')
+Text.Paragraph = createTextContainer('p')
 
-const DefaultProps = {
-  block: false,
-  inline: false,
-  smallcaps: false,
-  heading: -1,
-  size: '',
-  weight: '',
-  color: '',
-}
+const TypedText: ComponentType<Props> & TextComponentType = Text
 
-const Text = ({
-  block,
-  inline,
-  heading,
-  smallcaps,
-  size,
-  weight,
-  color,
-  children,
-  ...props
-}: Props) => {
-  const StyledComp = getStyledComponent({ inline, block, heading })
-  return (
-    <StyledComp
-      {...props}
-      weight={weight}
-      size={size}
-      smallcaps={smallcaps}
-      color={color}
-      children={children}
-    />
-  )
-}
-
-Text.defaultProps = DefaultProps
-
-export {
-  StyledBlock,
-  StyledInline,
-  StyledH1,
-  StyledH2,
-  StyledH3,
-  StyledH4,
-  StyledH5,
-  StyledH6,
-  StyledText,
-}
-export default Text
+export default TypedText

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -37,10 +37,22 @@ const styledHeadings = [
   StyledH6,
 ]
 
+const getStyledComponent = ({ heading, block = false, inline = false }) => {
+  if (block) return StyledBlock
+  if (inline) return StyledInline
+  if (heading) {
+    return (
+      styledHeadings[Math.max(1, Math.min(6, parseInt(heading, 10))) - 1] ||
+      StyledText
+    )
+  }
+  return StyledText
+}
+
 type Props = {
   block: boolean,
   inline: boolean,
-  heading: string | number, // Make this just a number?
+  heading: string | number,
   smallcaps: boolean,
   size: string,
   weight: string,
@@ -48,28 +60,41 @@ type Props = {
   children: Node,
 }
 
-const Text = ({ block, inline, heading, ...props }: Props) => {
-  /*
-  const Component =
-    (block && StyledBlock) ||
-    (inline && StyledInline) ||
-    (heading >= 1 && heading <= 6 && styledHeadings[heading - 1]) ||
-    StyledText
-  */
-  let Component = StyledText
-  if (block) {
-    Component = StyledBlock
-  } else if (inline) {
-    Component = StyledInline
-  } else if (heading) {
-    heading = parseInt(heading, 10)
-    if (heading >= 1 && heading <= 6) {
-      Component = styledHeadings[heading - 1]
-    }
-  }
-
-  return <Component {...props} />
+const DefaultProps = {
+  block: false,
+  inline: false,
+  smallcaps: false,
+  heading: -1,
+  size: '',
+  weight: '',
+  color: '',
 }
+
+const Text = ({
+  block,
+  inline,
+  heading,
+  smallcaps,
+  size,
+  weight,
+  color,
+  children,
+  ...props
+}: Props) => {
+  const StyledComp = getStyledComponent({ inline, block, heading })
+  return (
+    <StyledComp
+      {...props}
+      weight={weight}
+      size={size}
+      smallcaps={smallcaps}
+      color={color}
+      children={children}
+    />
+  )
+}
+
+Text.defaultProps = DefaultProps
 
 export {
   StyledBlock,

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -6,7 +6,6 @@ import theme from '../../theme'
 import { fontStyle } from '../../shared-styles'
 
 const StyledText = styled.p`
-  color: ${theme.textPrimary};
   ${({ size, weight }) => fontStyle({ size, weight })};
   ${({ smallcaps }) => {
     if (!smallcaps) return ''
@@ -16,7 +15,7 @@ const StyledText = styled.p`
     `
   }};
   ${({ color }) => {
-    return color ? `color: ${color}` : ''
+    return `color: ${color || theme.textPrimary}`
   }};
 `
 

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -37,22 +37,10 @@ const styledHeadings = [
   StyledH6,
 ]
 
-const getStyledComponent = ({ heading, block = false, inline = false }) => {
-  if (block) return StyledBlock
-  if (inline) return StyledInline
-  if (heading) {
-    return (
-      styledHeadings[Math.max(1, Math.min(6, parseInt(heading, 10))) - 1] ||
-      StyledText
-    )
-  }
-  return StyledText
-}
-
 type Props = {
   block: boolean,
   inline: boolean,
-  heading: string | number,
+  heading: string | number, // Make this just a number?
   smallcaps: boolean,
   size: string,
   weight: string,
@@ -60,41 +48,28 @@ type Props = {
   children: Node,
 }
 
-const DefaultProps = {
-  block: false,
-  inline: false,
-  smallcaps: false,
-  heading: -1,
-  size: '',
-  weight: '',
-  color: '',
-}
+const Text = ({ block, inline, heading, ...props }: Props) => {
+  /*
+  const Component =
+    (block && StyledBlock) ||
+    (inline && StyledInline) ||
+    (heading >= 1 && heading <= 6 && styledHeadings[heading - 1]) ||
+    StyledText
+  */
+  let Component = StyledText
+  if (block) {
+    Component = StyledBlock
+  } else if (inline) {
+    Component = StyledInline
+  } else if (heading) {
+    heading = parseInt(heading, 10)
+    if (heading >= 1 && heading <= 6) {
+      Component = styledHeadings[heading - 1]
+    }
+  }
 
-const Text = ({
-  block,
-  inline,
-  heading,
-  smallcaps,
-  size,
-  weight,
-  color,
-  children,
-  ...props
-}: Props) => {
-  const StyledComp = getStyledComponent({ inline, block, heading })
-  return (
-    <StyledComp
-      {...props}
-      weight={weight}
-      size={size}
-      smallcaps={smallcaps}
-      color={color}
-      children={children}
-    />
-  )
+  return <Component {...props} />
 }
-
-Text.defaultProps = DefaultProps
 
 export {
   StyledBlock,


### PR DESCRIPTION
Refactors `Text` to be more similar to `Button` (i.e. no element-switching).