### PR TITLE
DropDownItem: render DropDownItem as a <li>

### DIFF
--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -115,15 +115,14 @@ class DropDown extends React.Component<Props, State> {
                   }}
                 >
                   {items.map((item, i) => (
-                    <li key={i}>
-                      <DropDownItem
-                        index={i}
-                        active={i === active}
-                        onActivate={this.handleItemActivate}
-                      >
-                        {item}
-                      </DropDownItem>
-                    </li>
+                    <DropDownItem
+                      key={i}
+                      index={i}
+                      active={i === active}
+                      onActivate={this.handleItemActivate}
+                    >
+                      {item}
+                    </DropDownItem>
                   ))}
                 </DropDownItems>
               )

--- a/src/components/DropDown/DropDownItem.js
+++ b/src/components/DropDown/DropDownItem.js
@@ -7,7 +7,7 @@ import { unselectable } from '../../shared-styles'
 
 const { accent, contentBackgroundActive } = theme
 
-const StyledDropDownItem = styled.div.attrs({ tabIndex: '0' })`
+const StyledDropDownItem = styled.li.attrs({ tabIndex: '0' })`
   position: relative;
   padding: 8px 15px;
   cursor: pointer;


### PR DESCRIPTION
Rendering the `StyledDropDownItem` as a `<div>` rather than a `<li>` seems unnecessary... maybe I'm missing something?