### PR TITLE
publicURL: add injector component

### DIFF
--- a/gallery/src/App.js
+++ b/gallery/src/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import createHistory from 'history/createBrowserHistory'
 import styled from 'styled-components'
-import { AragonApp } from '@aragon/ui'
+import { BaseStyles, publicUrlInjector } from '@aragon/ui'
 import Sidebar from 'comps/Sidebar/Sidebar'
 import PageHome from 'pages/PageHome'
 import PageColors from 'pages/PageColors'
@@ -37,13 +37,13 @@ const preparePages = (path, pages) =>
     path: path + p[2].replace(/^\//, '') + (p[2] === '/' ? '' : '/'),
   }))
 
-const Main = styled.div`
+const Main = publicUrlInjector(styled.main`
   display: flex;
   height: 100%;
   > :first-child {
     margin-right: 20px;
   }
-`
+`)
 
 class App extends React.Component {
   state = {
@@ -73,16 +73,15 @@ class App extends React.Component {
     const { pages, activePage } = this.state
     const Page = activePage && activePage.comp
     return (
-      <AragonApp publicUrl="/">
-        <Main>
-          <Sidebar
-            pages={pages}
-            activePage={activePage}
-            onOpen={this.handleOpenPage}
-          />
-          {Page && <Page title={activePage.name} />}
-        </Main>
-      </AragonApp>
+      <Main publicUrl="/">
+        <BaseStyles />
+        <Sidebar
+          pages={pages}
+          activePage={activePage}
+          onOpen={this.handleOpenPage}
+        />
+        {Page && <Page title={activePage.name} />}
+      </Main>
     )
   }
 }

--- a/src/components/AragonApp/AragonApp.js
+++ b/src/components/AragonApp/AragonApp.js
@@ -1,7 +1,6 @@
 /* @flow */
 import type { Node } from 'react'
 import React from 'react'
-import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { BaseStyles, theme } from '../..'
 import { styledPublicUrl as asset } from '../../public-url'
@@ -22,7 +21,6 @@ const StyledAragonApp = styled.main`
 type Props = {
   className: string,
   backgroundLogo: boolean,
-  publicUrl: string,
   children: Node,
 }
 
@@ -30,18 +28,11 @@ class AragonApp extends React.Component<Props> {
   static defaultProps = {
     backgroundLogo: false,
   }
-  static childContextTypes = {
-    publicUrl: PropTypes.string,
-  }
   static Styled = StyledAragonApp
 
-  getChildContext() {
-    return { publicUrl: this.props.publicUrl }
-  }
-
   render() {
-    const { children, backgroundLogo, className, publicUrl } = this.props
-    const styledProps = { backgroundLogo, className, publicUrl }
+    const { children, backgroundLogo, className } = this.props
+    const styledProps = { backgroundLogo, className }
     return (
       <StyledAragonApp {...styledProps}>
         <BaseStyles />

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export {
   default as styled,
 } from 'styled-components'
 
+export { publicUrlInjector } from './public-url'
 export { default as theme, themeDark, brand, colors } from './theme'
 export {
   font,

--- a/src/public-url.js
+++ b/src/public-url.js
@@ -1,7 +1,8 @@
+/* @flow */
 import React from 'react'
 import PropTypes from 'prop-types'
 
-// High order component wrapper
+// High order component "get" wrapper
 const getPublicUrl = Component => {
   const highOrderComponent = (baseProps, context) => {
     const { publicUrl = '' } = context
@@ -14,6 +15,26 @@ const getPublicUrl = Component => {
   return highOrderComponent
 }
 
+type UrlInjectorProps = {
+  publicUrl: string,
+}
+
+// High order component "set" wrapper
+const publicUrlInjector = Component => {
+  class PublicUrlContextInjector extends React.Component<UrlInjectorProps> {
+    getChildContext() {
+      return { publicUrl: this.props.publicUrl }
+    }
+    static childContextTypes = {
+      publicUrl: PropTypes.string,
+    }
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+  return PublicUrlContextInjector
+}
+
 // prefix helper
 const prefixUrl = (url, publicUrl) =>
   url.startsWith('data:') ? url : publicUrl + url
@@ -21,5 +42,5 @@ const prefixUrl = (url, publicUrl) =>
 // styled-component helper
 const styledPublicUrl = url => ({ publicUrl }) => prefixUrl(url, publicUrl)
 
-export { prefixUrl, styledPublicUrl }
+export { prefixUrl, publicUrlInjector, styledPublicUrl }
 export default getPublicUrl


### PR DESCRIPTION
Adds a new `publicUrlInjector()` HOC to decouple the publicURL context injector from AragonApp.

This allows consumers of the library to choose their root element, rather than having to always wrap an `AragonApp` around it.

Thoughts @bpierre?

Todo:
* [ ] Fix docs
* [ ] Fix other repos relying on previous behaviour