### PR TITLE
publicURL: return an explicit component from getPublicUrl

### DIFF
--- a/src/public-url.js
+++ b/src/public-url.js
@@ -2,16 +2,20 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 // High order component wrapper
+// Note that using this HOC on a styled component will destroy that component's ability to be used
+// in a reverse selector
 const getPublicUrl = Component => {
-  const highOrderComponent = (baseProps, context) => {
-    const { publicUrl = '' } = context
-    const props = { ...baseProps, publicUrl }
-    return <Component {...props} />
+  class WithPublicUrl extends React.Component {
+    static contextTypes = {
+      publicUrl: PropTypes.string,
+    }
+    render() {
+      const { publicUrl = '' } = this.context
+      const props = { ...this.props, publicUrl }
+      return <Component {...props} />
+    }
   }
-  highOrderComponent.contextTypes = {
-    publicUrl: PropTypes.string,
-  }
-  return highOrderComponent
+  return WithPublicUrl
 }
 
 // prefix helper


### PR DESCRIPTION
`styled-components` expects elements used in reverse selectors to be self-contained, executable functions. Wrapping a styled component with `getPublicUrl()` breaks this, however, as it forces the component to rely on an injected context.

Componentizing the returned wrapper component from `getPublicUrl()` results in better error messages if a consumer tries to use the element in a reverse selector.

Todo:
* [ ] We should probably write some docs on this

----------

I'm not sure if putting another `styled()` on top of a component wrapped by `getPublicUrl()` allows them to be used in reverse selectors (should; I don't see why it wouldn't), but if it does, this should be transparent to a consumer of the library since they'll be using `styled()` if they want reverse selectors anyway.