### PR TITLE
Change the optimize:svg task to preserve the viewBox attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",
     "theme:build": "scripts/oco-json.js < src/theme/Aragon.oco > src/theme/aragon.json",
-    "optimize:svg": "find ./src -name *.svg -exec svgo --config '{ \"plugins\": [ { \"removeDesc\": {\"removeAny\": true} }, { \"removeTitle\": true } ] }' {} \\;",
+    "optimize:svg": "find ./src -name *.svg -exec svgo --config '{ \"plugins\": [ { \"removeDesc\": {\"removeAny\": true} }, { \"removeTitle\": true }, { \"removeViewBox\": false } ] }' {} \\;",
     "deploy:site": "cd gallery && npm run build:production && echo 'ui.aragon.one' > dist/CNAME && cp public/favicon.svg dist && gh-pages -d dist",
     "publish": "npm publish --access public",
     "start": "cd gallery && npm start"


### PR DESCRIPTION
Having the `viewBox` attribute removed prevent scaling SVG images. This PR tells svgo to preserve this attribute.

See the discussion in https://github.com/aragon/aragon-ui/pull/28