### PR TITLE
Color updates

### DIFF
--- a/src/theme/Aragon.oco
+++ b/src/theme/Aragon.oco
@@ -77,10 +77,12 @@ Aragon UI:
   shadow: =Grey.Gainsboro
   textPrimary: =Black.Black
   textSecondary: =Grey.Dim Grey
-  textTertiary: =Grey.Dim Grey
+  textTertiary: =Grey.Light Grey
   accent: =Eagle.Dark Turquoise
   positive: =Green.Spring Green
+  positiveText: =White.White
   negative: =Red.Salmon Red
+  negativeText: =White.White
 Aragon UI Dark:
   oct/
     view: List
@@ -104,4 +106,6 @@ Aragon UI Dark:
   textTertiary: =Grey.Dim Grey
   accent: =Eagle.Dark Turquoise
   positive: =Green.Spring Green
+  positiveText: =White.White
   negative: =Red.Salmon Red
+  negativeText: =White.White

--- a/src/theme/aragon.json
+++ b/src/theme/aragon.json
@@ -78,10 +78,12 @@
     "shadow": "=Grey.Gainsboro",
     "textPrimary": "=Black.Black",
     "textSecondary": "=Grey.Dim Grey",
-    "textTertiary": "=Grey.Dim Grey",
+    "textTertiary": "=Grey.Light Grey",
     "accent": "=Eagle.Dark Turquoise",
     "positive": "=Green.Spring Green",
-    "negative": "=Red.Salmon Red"
+    "positiveText": "=White.White",
+    "negative": "=Red.Salmon Red",
+    "negativeText": "=White.White"
   },
   "Aragon UI Dark": {
     "gradientStart": "=Eagle.Cerulean",
@@ -103,6 +105,8 @@
     "textTertiary": "=Grey.Dim Grey",
     "accent": "=Eagle.Dark Turquoise",
     "positive": "=Green.Spring Green",
-    "negative": "=Red.Salmon Red"
+    "positiveText": "=White.White",
+    "negative": "=Red.Salmon Red",
+    "negativeText": "=White.White"
   }
 }


### PR DESCRIPTION
This commit adds two new colors:

- positiveText
- negativeText

They are both white and should be used for text or outlines that are on
top of the “positive” and “negative“ colors.

It also fixes the color of theme.textTertiary for the light theme,
which was the same as theme.textSecondary.