### PR TITLE
BadgeNumber

### DIFF
--- a/src/components/BadgeNumber/BadgeNumber.js
+++ b/src/components/BadgeNumber/BadgeNumber.js
@@ -1,6 +1,7 @@
 import React from 'react'
-
-import { styled, theme, font } from '../..'
+import styled from 'styled-components'
+import theme from '../../theme'
+import { font } from '../../shared-styles'
 
 const BadgeNumber = ({ number = 0, small = false, ...props }) => (
   <Main small={small} {...props}>

--- a/src/components/BadgeNumber/BadgeNumber.js
+++ b/src/components/BadgeNumber/BadgeNumber.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import { styled, theme, font } from '../..'
+
+const BadgeNumber = ({ number = 0, small = false, ...props }) => (
+  <Main small={small} {...props}>
+    {number}
+  </Main>
+)
+
+const Main = styled.span`
+  display: flex;
+  overflow: hidden;
+  justify-content: center;
+  align-items: center;
+  padding-top: 1px;
+  width: ${({ small }) => (small ? '14' : '18')}px;
+  height: ${({ small }) => (small ? '14' : '18')}px;
+  line-height: ${({ small }) => (small ? '13' : '17')}px;
+  border-radius: ${({ small }) => (small ? '7' : '9')}px;
+  font-size: ${({ small }) => (small ? '10' : '12')}px;
+  font-weight: 600;
+  color: ${theme.positiveText};
+  background: ${theme.positive};
+`
+
+export default BadgeNumber

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ export { default as Section } from './components/Section/Section'
 export {
   default as IllustratedSection,
 } from './components/IllustratedSection/IllustratedSection'
+export { default as BadgeNumber } from './components/BadgeNumber/BadgeNumber'
 export { default as Button } from './components/Button/Button'
 export { default as DropDown } from './components/DropDown/DropDown'
 export { default as Field } from './components/Form/Field'

--- a/src/theme/Aragon.oco
+++ b/src/theme/Aragon.oco
@@ -77,10 +77,12 @@ Aragon UI:
   shadow: =Grey.Gainsboro
   textPrimary: =Black.Black
   textSecondary: =Grey.Dim Grey
-  textTertiary: =Grey.Dim Grey
+  textTertiary: =Grey.Light Grey
   accent: =Eagle.Dark Turquoise
   positive: =Green.Spring Green
+  positiveText: =White.White
   negative: =Red.Salmon Red
+  negativeText: =White.White
 Aragon UI Dark:
   oct/
     view: List
@@ -104,4 +106,6 @@ Aragon UI Dark:
   textTertiary: =Grey.Dim Grey
   accent: =Eagle.Dark Turquoise
   positive: =Green.Spring Green
+  positiveText: =White.White
   negative: =Red.Salmon Red
+  negativeText: =White.White

--- a/src/theme/aragon.json
+++ b/src/theme/aragon.json
@@ -78,10 +78,12 @@
     "shadow": "=Grey.Gainsboro",
     "textPrimary": "=Black.Black",
     "textSecondary": "=Grey.Dim Grey",
-    "textTertiary": "=Grey.Dim Grey",
+    "textTertiary": "=Grey.Light Grey",
     "accent": "=Eagle.Dark Turquoise",
     "positive": "=Green.Spring Green",
-    "negative": "=Red.Salmon Red"
+    "positiveText": "=White.White",
+    "negative": "=Red.Salmon Red",
+    "negativeText": "=White.White"
   },
   "Aragon UI Dark": {
     "gradientStart": "=Eagle.Cerulean",
@@ -103,6 +105,8 @@
     "textTertiary": "=Grey.Dim Grey",
     "accent": "=Eagle.Dark Turquoise",
     "positive": "=Green.Spring Green",
-    "negative": "=Red.Salmon Red"
+    "positiveText": "=White.White",
+    "negative": "=Red.Salmon Red",
+    "negativeText": "=White.White"
   }
 }


### PR DESCRIPTION
Depends on https://github.com/aragon/aragon-ui/pull/33.

This PR adds a `<BadgeNumber />` component:

<img width="93" alt="image" src="https://user-images.githubusercontent.com/36158/33500532-065d421e-d6d1-11e7-8942-41d05ff20651.png">

It can be used to indicate the available notifications and other things (updates, messages, etc.). Its color is `theme.positive` for now, that could evolve in the future.

### Positioning

Maybe we could also provide something to help positioning it on top of an icon, like this:

<img width="90" alt="image" src="https://user-images.githubusercontent.com/36158/33499858-a6d0c048-d6ce-11e7-8343-6fa86e547f4e.png">

We could add a property to icon components?

```jsx
<IconWallet badgeNumber={7} />
```

But we might want to position it on top of other things than icons.

Or by having an wrapping component:

```jsx
<BadgeNumber.Attacher>
  <IconWallet />
  <BadgeNumber number={7} />
</BadgeNumber.Attacher>
```

Or by considering that app authors can position it themselves.

Any thoughts?