### PR TITLE
SidePanel: fix close button's src pathing

### DIFF
--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -6,7 +6,7 @@ import { Motion, spring } from 'react-motion'
 import Text from '../Text/Text'
 import { lerp } from '../../math-utils'
 import { springConf } from '../../shared-styles'
-import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
+import getPublicUrl, { prefixUrl } from '../../public-url'
 
 import close from './assets/close.svg'
 
@@ -78,9 +78,10 @@ type Props = {
   title: string,
   opened: boolean,
   onClose?: mixed,
+  publicUrl: string,
 }
 
-const SidePanel = ({ children, title, opened, onClose }: Props) => {
+const SidePanel = ({ children, title, opened, onClose, publicUrl }: Props) => {
   return (
     <Motion style={{ progress: spring(Number(opened), springConf('slow')) }}>
       {({ progress }) => {
@@ -94,7 +95,7 @@ const SidePanel = ({ children, title, opened, onClose }: Props) => {
                   {title}
                 </Text>
                 <StyledPanelCloseButton type="button" onClick={onClose}>
-                  <img src={asset(close)} alt="Close" />
+                  <img src={prefixUrl(close, publicUrl)} alt="Close" />
                 </StyledPanelCloseButton>
               </StyledPanelHeader>
               {children}


### PR DESCRIPTION
Oops, missed that `styledPublicUrl()` is a HOF meant to be used with `css()`.

Fixes SidePanel so that its close button's img src is built with `prefixUrl()` instead.