### PR TITLE
Dropdown fixes

### DIFF
--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -22,7 +22,7 @@ const StyledDropDown = styled.div`
   }
 `
 
-const DropDownItems = styled.ul`
+const DropDownItems = styled.div`
   display: ${({ opened }) => (opened ? 'block' : 'none')};
   min-width: 100%;
   padding: 8px 0;
@@ -108,6 +108,7 @@ class DropDown extends React.Component<Props, State> {
               const scale = opened ? lerp(openProgress, 0.95, 1) : 1
               return (
                 <DropDownItems
+                  role="listbox"
                   opened={openProgress > 0}
                   style={{
                     transform: `scale(${scale},${scale})`,
@@ -116,6 +117,7 @@ class DropDown extends React.Component<Props, State> {
                 >
                   {items.map((item, i) => (
                     <DropDownItem
+                      role="option"
                       key={i}
                       index={i}
                       active={i === active}

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Motion, spring } from 'react-motion'
 import ClickOutHandler from 'react-onclickout'
 import theme from '../../theme'
-import { springConf } from '../../shared-styles'
+import { springConf, unselectable } from '../../shared-styles'
 import { lerp } from '../../math-utils'
 import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import DropDownItem from './DropDownItem'
@@ -16,9 +16,12 @@ const { contentBackground, contentBorder, textPrimary } = theme
 
 const StyledDropDown = styled.div`
   position: relative;
+  display: ${({wide}) => wide? 'flex' : 'inline-flex'};
+  flex-direction: column;
   color: ${textPrimary};
   white-space: nowrap;
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.03);
+  ${unselectable};
   &:focus {
     outline: 0;
   }
@@ -26,7 +29,7 @@ const StyledDropDown = styled.div`
 
 const DropDownItems = styled.div`
   display: ${({ opened }) => (opened ? 'block' : 'none')};
-  min-width: 100%;
+  min-width: ${({wide}) => wide? '100%' : '0'};
   padding: 8px 0;
   position: absolute;
   z-index: 2;
@@ -56,6 +59,7 @@ const DropDownActiveItem = getPublicUrl(styled(DropDownItem)`
 
 type Props = {
   items: Array<string>,
+  wide: boolean,
   active: number,
   onChange: number => mixed,
 }
@@ -68,6 +72,7 @@ class DropDown extends React.Component<Props, State> {
   static defaultProps = {
     items: [],
     active: 0,
+    wide: false,
     onChange: () => {},
   }
   activeItemElt: ?HTMLElement
@@ -88,12 +93,12 @@ class DropDown extends React.Component<Props, State> {
     }
   }
   render() {
-    const { items, active } = this.props
+    const { items, active, wide } = this.props
     const { opened } = this.state
     const activeItem = items[active] || items[0]
     return (
       <ClickOutHandler onClickOut={this.handleClose}>
-        <StyledDropDown>
+        <StyledDropDown wide={wide}>
           <DropDownActiveItem
             onActivate={this.handleToggle}
             mainRef={el => (this.activeItemElt = el)}
@@ -107,11 +112,12 @@ class DropDown extends React.Component<Props, State> {
             }}
           >
             {({ openProgress, closeProgress }) => {
-              const scale = opened ? lerp(openProgress, 0.95, 1) : 1
+              const scale = opened ? lerp(openProgress, 0.98, 1) : 1
               return (
                 <DropDownItems
                   role="listbox"
                   opened={openProgress > 0}
+                  wide={wide}
                   style={{
                     transform: `scale(${scale},${scale})`,
                     opacity: opened ? openProgress : closeProgress,

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -10,6 +10,8 @@ import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import DropDownItem from './DropDownItem'
 import arrow from './assets/arrow-down.svg'
 
+const NON_BREAKING_SPACE = '\xa0'
+
 const { contentBackground, contentBorder, textPrimary } = theme
 
 const StyledDropDown = styled.div`
@@ -115,17 +117,19 @@ class DropDown extends React.Component<Props, State> {
                     opacity: opened ? openProgress : closeProgress,
                   }}
                 >
-                  {items.map((item, i) => (
-                    <DropDownItem
-                      role="option"
-                      key={i}
-                      index={i}
-                      active={i === active}
-                      onActivate={this.handleItemActivate}
-                    >
-                      {item}
-                    </DropDownItem>
-                  ))}
+                  {items.length
+                    ? items.map((item, i) => (
+                        <DropDownItem
+                          role="option"
+                          key={i}
+                          index={i}
+                          active={i === active}
+                          onActivate={this.handleItemActivate}
+                        >
+                          {item}
+                        </DropDownItem>
+                      ))
+                    : NON_BREAKING_SPACE}
                 </DropDownItems>
               )
             }}

--- a/src/components/DropDown/DropDownItem.js
+++ b/src/components/DropDown/DropDownItem.js
@@ -5,6 +5,8 @@ import styled from 'styled-components'
 import theme from '../../theme'
 import { unselectable } from '../../shared-styles'
 
+const NON_BREAKING_SPACE = '\xa0'
+
 const { accent, contentBackgroundActive } = theme
 
 const StyledDropDownItem = styled.div.attrs({ tabIndex: '0' })`
@@ -74,7 +76,12 @@ class DropDownItem extends React.Component<Props, State> {
     this.setState({ displayFocus: !this.state.pressed })
   }
   render() {
-    const { children, className, mainRef, active } = this.props
+    const {
+      children = NON_BREAKING_SPACE,
+      className,
+      mainRef,
+      active,
+    } = this.props
     const { displayFocus } = this.state
     return (
       <StyledDropDownItem

--- a/src/components/DropDown/DropDownItem.js
+++ b/src/components/DropDown/DropDownItem.js
@@ -3,7 +3,6 @@ import type { Node } from 'react'
 import React from 'react'
 import styled from 'styled-components'
 import theme from '../../theme'
-import { unselectable } from '../../shared-styles'
 
 const NON_BREAKING_SPACE = '\xa0'
 
@@ -14,7 +13,6 @@ const StyledDropDownItem = styled.div.attrs({ tabIndex: '0' })`
   padding: 8px 15px;
   cursor: pointer;
   outline: 0;
-  ${unselectable};
   &:after {
     content: '';
     opacity: 0;

--- a/src/components/DropDown/DropDownItem.js
+++ b/src/components/DropDown/DropDownItem.js
@@ -53,6 +53,9 @@ type State = {
 }
 
 class DropDownItem extends React.Component<Props, State> {
+  static defaultProps = {
+    children: NON_BREAKING_SPACE,
+  }
   state = {
     pressed: false,
     displayFocus: false,
@@ -74,12 +77,7 @@ class DropDownItem extends React.Component<Props, State> {
     this.setState({ displayFocus: !this.state.pressed })
   }
   render() {
-    const {
-      children = NON_BREAKING_SPACE,
-      className,
-      mainRef,
-      active,
-    } = this.props
+    const { children, className, mainRef, active } = this.props
     const { displayFocus } = this.state
     return (
       <StyledDropDownItem

--- a/src/components/DropDown/DropDownItem.js
+++ b/src/components/DropDown/DropDownItem.js
@@ -7,7 +7,7 @@ import { unselectable } from '../../shared-styles'
 
 const { accent, contentBackgroundActive } = theme
 
-const StyledDropDownItem = styled.li.attrs({ tabIndex: '0' })`
+const StyledDropDownItem = styled.div.attrs({ tabIndex: '0' })`
   position: relative;
   padding: 8px 15px;
   cursor: pointer;

--- a/src/components/DropDown/README.md
+++ b/src/components/DropDown/README.md
@@ -55,3 +55,10 @@ Set this property to the index of the active item.
 - Default: `undefined`
 
 This callback is called whenever the user selects a new item.
+
+### `wide`
+
+- Type: `Boolean`
+- Default: `false`
+
+Takes the full width if set to `true`.

--- a/src/components/DropDown/README.md
+++ b/src/components/DropDown/README.md
@@ -49,7 +49,7 @@ Use this property to define the items of the DropDown menu.
 
 Set this property to the index of the active item.
 
-### `handleChange`
+### `onChange`
 
 - Type: `Function`
 - Default: `undefined`


### PR DESCRIPTION
A few fixes for the DropDown component:

- Use `role` attributes to make the component more accessible by screen readers.
- Revert back to use `<div>` for DropDownItem (the item is also used outside of `<ul>`).
- Default height when the component is empty (so that it doesn’t look broken).
- Fix a typo in the README.
- Add a `wide` property.