### PR TITLE
Add Button.Anchor

### DIFF
--- a/gallery/src/pages/PageButton.js
+++ b/gallery/src/pages/PageButton.js
@@ -3,17 +3,24 @@ import styled from 'styled-components'
 import Page from 'comps/Page/Page'
 
 import readme from 'ui-src/components/Button/README.md'
-import { Button, colors } from '@aragon/ui'
+import { Button } from '@aragon/ui'
 
 const Container = styled.div`
   display: flex;
   max-width: 800px;
+  &:not(:last-child) {
+    margin-bottom: 20px;
+  }
   & > div {
     margin-left: 20px;
   }
   & > div:first-child {
     margin: 0;
   }
+`
+
+const DemoHeader = styled.h4`
+  margin-bottom: 10px;
 `
 
 const PageButton = ({ title }) => (
@@ -31,6 +38,14 @@ const PageButton = ({ title }) => (
         </div>
         <div>
           <Button mode="text">Text Mode</Button>
+        </div>
+      </Container>
+      <DemoHeader>Button.Anchor</DemoHeader>
+      <Container>
+        <div>
+          <Button.Anchor href="https://aragon.one/" target="_blank">
+            Link Button
+          </Button.Anchor>
         </div>
       </Container>
     </Page.Demo>

--- a/gallery/yarn.lock
+++ b/gallery/yarn.lock
@@ -9,7 +9,6 @@
     prop-types "^15.6.0"
     react-motion "^0.5.2"
     react-onclickout "^2.0.8"
-    react-responsive "^3.0.0"
     styled-components "^2.2.3"
 
 abbrev@1:
@@ -1260,10 +1259,6 @@ css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
 
-css-mediaquery@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
-
 css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -2163,10 +2158,6 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-hyphenate-style-name@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
 iconv-lite@0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -2611,12 +2602,6 @@ markdown-it@^8.4.0:
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.3"
-
-matchmediaquery@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.2.1.tgz#223c7005793de03e47ce92b13285a72c44ada2cf"
-  dependencies:
-    css-mediaquery "^0.1.2"
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -3154,7 +3139,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3290,14 +3275,6 @@ react-motion@^0.5.2:
 react-onclickout@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/react-onclickout/-/react-onclickout-2.0.8.tgz#d178b13fb87a481356761b454aa60df7069b2da4"
-
-react-responsive@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-3.0.0.tgz#26e895dbdf748d4473c76cf46d29cb9d824e02ec"
-  dependencies:
-    hyphenate-style-name "^1.0.0"
-    matchmediaquery "^0.2.1"
-    prop-types "^15.5.7"
 
 react@^16.0.0:
   version "16.0.0"

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -116,8 +116,7 @@ type Props = {
   wide?: boolean,
 }
 
-// Flow declaration: see https://github.com/styled-components/styled-components/issues/570#issuecomment-332087358
-const StyledButton: ComponentType<Props> = getPublicUrl(styled.button`
+const StyledButton = styled.button`
   width: ${({ wide }) => (wide ? '100%' : 'auto')};
   padding: 10px 15px;
   white-space: nowrap;
@@ -152,7 +151,24 @@ const StyledButton: ComponentType<Props> = getPublicUrl(styled.button`
     if (emphasis === 'negative') return negativeStyle
     return ''
   }};
-`)
+`
 
-export { StyledButton }
-export default StyledButton
+type ButtonComponentType = {
+  Anchor: ComponentType<Props>,
+}
+
+// Flow declaration: see https://github.com/styled-components/styled-components/issues/570#issuecomment-332087358
+// Currently throwing errors: https://github.com/styled-components/styled-components/issues/1350
+const Button: ComponentType<Props> & ButtonComponentType = getPublicUrl(
+  StyledButton
+)
+const Anchor: ComponentType<Props> = getPublicUrl(
+  StyledButton.withComponent('a').extend`
+    display: inline-block;
+    text-decoration: none;
+  `
+)
+
+Button.Anchor = Anchor
+
+export default Button

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -46,3 +46,19 @@ const MyButton = () => (
   <Button wide>Accept</Button>
 )
 ```
+
+## Attached Components
+
+### `Anchor`
+
+An `<a>` styled to be visually similar to Buttons, supporting the same properties.
+
+#### Example:
+
+```jsx
+const LinkButton = () => (
+  <Button.Anchor mode="strong" href="https://aragon.one/" target="_blank">
+    Aragon
+  </Button.Anchor>
+)
+```

--- a/src/components/Card/EmptyStateCard.js
+++ b/src/components/Card/EmptyStateCard.js
@@ -20,6 +20,7 @@ const StyledHeading = StyledH1.extend`
   margin: 20px 0 5px;
 `
 
+// $FlowFixMe
 const StyledActionButton = styled(Button)`
   width: 150px;
   margin-top: 20px;


### PR DESCRIPTION
Required for https://github.com/aragon/aragon/issues/66.

Maybe not the most "component"y (it'd be nice if people didn't have to care about `<a>`s and `Button`s exposed a linking API that didn't reinvent the wheel), but certainly the simplest.

Adds a demo to the gallery:
![image](https://user-images.githubusercontent.com/4166642/33858756-ffc0e71e-de9e-11e7-97e8-443256f6c6f0.png)
