### PR TITLE
Gallery: add markdown-it-anchor

### DIFF
--- a/gallery/src/render-readme.js
+++ b/gallery/src/render-readme.js
@@ -1,4 +1,5 @@
 import MarkdownIt from 'markdown-it'
+import MarkdownItAnchor from 'markdown-it-anchor'
 
 import Prism from 'prismjs'
 import 'prismjs/components/prism-markup'
@@ -50,6 +51,9 @@ const splitIntro = html => {
 
 const md = new MarkdownIt()
 md.use(markdownItPrism)
+md.use(MarkdownItAnchor, {
+  level: [2, 3],
+})
 
 export default async url => {
   const result = await fetch(url)

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "flow-bin": "^0.60.1",
     "gh-pages": "^1.0.0",
+    "markdown-it-anchor": "^4.0.0",
     "opencolor": "^0.2.0",
     "opencolor-converter": "git://github.com/opencolor-tools/opencolor-converter.git#v2.1.21",
     "prettier": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,6 +2906,12 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+markdown-it-anchor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-4.0.0.tgz#e87fb5543e01965adf71506c6bf7b0491841b7e3"
+  dependencies:
+    string "^3.3.3"
+
 mdn-data@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-1.0.0.tgz#a69d9da76847b4d5834c1465ea25c0653a1fbf66"
@@ -4036,6 +4042,10 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
 string_decoder@~0.10.x:
   version "0.10.31"


### PR DESCRIPTION
Adds `id=<header-title>` attributes to h2 and h3 headers parsed from each component's readme.

Useful for intra-document linking, e.g. to reference a specific property or group from another part of the same document. Doesn't work for permalinking, due to the way routing is handled in the gallery.