### PR TITLE
Show display names of styled components in builds

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,8 @@
 {
   "plugins": [
     ["inline-json-import", {}],
-    ["babel-plugin-styled-components", {
-      "displayName": false
+    ["styled-components", {
+      "displayName": true
     }]
   ],
   "presets": [["env", { "modules": false }], "react", "stage-2", "flow"]


### PR DESCRIPTION
Enables display names for users of this component library.

Increases the build size by ~2-3kb, which I think is OK for now given the quality of life upgrade. In the future, we can have a production build where this is turned off, or perhaps even better, change the plugin so that all the display names are under a `NODE_ENV` flag.