### PR TITLE
[DON'T MERGE] Add babel-plugin-flow-react-proptypes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
     ["inline-json-import", {}],
     ["styled-components", {
       "displayName": true
-    }]
+    }],
+    ["flow-react-proptypes"]
   ],
   "presets": [["env", { "modules": false }], "react", "stage-2", "flow"]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.1",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-flow-react-proptypes": "^12.1.0",
     "babel-plugin-inline-json-import": "^0.2.1",
     "babel-plugin-styled-components": "^1.3.0",
     "babel-polyfill": "^6.26.0",
@@ -67,7 +69,6 @@
     "svgr": "^1.1.0"
   },
   "dependencies": {
-    "babel-plugin-external-helpers": "^6.22.0",
     "prop-types": "^15.6.0",
     "react-motion": "^0.5.2",
     "react-onclickout": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,7 +283,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.26.0:
+babel-core@^6.25.0, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -472,6 +472,15 @@ babel-plugin-external-helpers@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-flow-react-proptypes@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-flow-react-proptypes/-/babel-plugin-flow-react-proptypes-12.1.0.tgz#cfa5d93b954a22783e8d6fc4553307b2b02ac3c8"
+  dependencies:
+    babel-core "^6.25.0"
+    babel-template "^6.25.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
 
 babel-plugin-inline-json-import@^0.2.1:
   version "0.2.1"
@@ -890,7 +899,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-template@^6.24.1, babel-template@^6.26.0:
+babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
   dependencies:
@@ -900,7 +909,7 @@ babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.24.1, babel-traverse@^6.25.0, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -914,7 +923,7 @@ babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:


### PR DESCRIPTION
Unfortunately, this wasn't as easy as just dropping in the plugin, because of [this issue](https://github.com/brigand/babel-plugin-flow-react-proptypes/issues/157)—[MenuItem's type export](https://github.com/aragon/aragon-ui/blob/master/src/components/Header/MenuItem.js#L7) breaks the bundled rollup build D:

This looks like it might be more of a rollup issue than the plugin's, and that it might have a long lead time to fix. It's not ideal, but one solution is to avoid local exports of types altogether given that we're not using them that much anyway.