### PR TITLE
EmptyStateCard: generalize input components

### DIFF
--- a/src/components/Card/EmptyStateCard.js
+++ b/src/components/Card/EmptyStateCard.js
@@ -1,4 +1,5 @@
 /* @flow */
+import type { Node } from 'react'
 import React from 'react'
 import styled from 'styled-components'
 import theme from '../../theme'
@@ -27,6 +28,7 @@ const StyledActionButton = styled(Button)`
 `
 
 type Props = {
+  actionButton: Node,
   actionText: string,
   icon: string,
   onActivate: mixed,
@@ -35,6 +37,7 @@ type Props = {
 }
 
 const DefaultProps = {
+  actionButton: StyledActionButton,
   title: 'Nothing here.',
 }
 
@@ -44,6 +47,7 @@ const EmptyStateCard = ({
   onActivate,
   text,
   title,
+  actionButton: ActionButton,
   ...props
 }: Props) => (
   <StyledCard {...props}>
@@ -55,9 +59,9 @@ const EmptyStateCard = ({
         </Text>
       </StyledHeading>
       <Text.Block>{text}</Text.Block>
-      <StyledActionButton mode="strong" onClick={onActivate}>
+      <ActionButton mode="strong" onClick={onActivate}>
         {actionText}
-      </StyledActionButton>
+      </ActionButton>
     </section>
   </StyledCard>
 )

--- a/src/components/Card/EmptyStateCard.js
+++ b/src/components/Card/EmptyStateCard.js
@@ -30,7 +30,7 @@ const StyledActionButton = styled(Button)`
 type Props = {
   actionButton: Node,
   actionText: string,
-  icon: string,
+  icon: Node,
   onActivate: mixed,
   text: string,
   title: string,
@@ -43,16 +43,16 @@ const DefaultProps = {
 
 const EmptyStateCard = ({
   actionText,
-  icon,
   onActivate,
   text,
   title,
   actionButton: ActionButton,
+  icon: Icon,
   ...props
 }: Props) => (
   <StyledCard {...props}>
     <section>
-      <img src={icon} alt="" />
+      <Icon />
       <StyledHeading>
         <Text color={theme.accent} weight="bold" size="large">
           {title}


### PR DESCRIPTION
Makes it easier to use `EmptyStateCard` in apps, who might want to supply their own button (e.g. an anchor) and a non-local static asset for the icon.