### PR TITLE
Button: add secondary mode

### DIFF
--- a/gallery/src/pages/PageButton.js
+++ b/gallery/src/pages/PageButton.js
@@ -31,6 +31,9 @@ const PageButton = ({ title }) => (
           <Button>Normal Button</Button>
         </div>
         <div>
+          <Button mode="secondary">Secondary Button</Button>
+        </div>
+        <div>
           <Button mode="strong">Strong Mode</Button>
         </div>
         <div>

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -16,6 +16,7 @@ const {
   contentBackground,
   contentBorder,
   contentBorderActive,
+  secondaryBackground,
   textPrimary,
   textSecondary,
 } = theme
@@ -52,6 +53,15 @@ const modeNormal = css`
   ${plainButtonStyles};
   &:active {
     color: ${textPrimary};
+  }
+`
+
+const modeSecondary = css`
+  ${plainButtonStyles};
+  background: ${secondaryBackground};
+  &:hover,
+  &:focus {
+    box-shadow: none;
   }
 `
 
@@ -107,7 +117,7 @@ const negativeStyle = css`
   background: url(${asset(cross)}) no-repeat 10px calc(50% - 1px);
 `
 
-type Mode = 'normal' | 'strong' | 'outline' | 'text'
+type Mode = 'normal' | 'secondary' | 'strong' | 'outline' | 'text'
 type Emphasis = 'positive' | 'negative'
 type Props = {
   compact?: boolean,
@@ -138,6 +148,7 @@ const StyledButton = styled.button`
   }
 
   ${({ mode }) => {
+    if (mode === 'secondary') return modeSecondary
     if (mode === 'strong') return modeStrong
     if (mode === 'outline') return modeOutline
     if (mode === 'text') return modeText

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -17,7 +17,7 @@ const App = () => (
 ### `mode`
 
 - Type: `String`
-- Values: `normal` (default), `outline`, `strong` or `text`.
+- Values: `normal` (default), `secondary`, `outline`, `strong` or `text`.
 
 Set this property to the desired visual variant.
 


### PR DESCRIPTION
<img width="160" alt="screen shot 2018-01-09 at 7 44 12 pm" src="https://user-images.githubusercontent.com/4166642/34753490-823d2774-f575-11e7-9ce6-f8a82d90fce1.png">

Required for the [voting app (see bottom button)](https://scene.zeplin.io/project/59a827960d4c4cb2274007f5/screen/59a82800d913ba794a4a5b4a).