### PR TITLE
unselectable: always invoke when interpolated by styled-components

### DIFF
--- a/src/components/AragonApp/AppBar.js
+++ b/src/components/AragonApp/AppBar.js
@@ -16,7 +16,7 @@ const StyledAppBar = styled.div`
   height: 64px;
   background: ${theme.contentBackground};
   border-bottom: 1px solid ${theme.contentBorder};
-  ${unselectable};
+  ${unselectable()};
 `
 
 const StyledAppBarStart = styled.div`

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -22,7 +22,7 @@ const StyledDropDown = styled.div`
   color: ${textPrimary};
   white-space: nowrap;
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.03);
-  ${unselectable};
+  ${unselectable()};
   &:focus {
     outline: 0;
   }


### PR DESCRIPTION
From discussion in #79.

Always invoke argument-less functions when used in components styled by `styled-components`.