### PR TITLE
PreFooter: invoke default email form as component

### DIFF
--- a/src/components/PreFooter/PreFooter.js
+++ b/src/components/PreFooter/PreFooter.js
@@ -101,7 +101,7 @@ const Container = getPublicUrl(styled(Section).attrs({ visual: true })`
   `)};
 `)
 
-const emailFormDefault = () => (
+const EmailFormDefault = () => (
   <div>
     <h1 className="title">Aragon Newsletter</h1>
     <p className="desc">
@@ -118,7 +118,7 @@ type Props = {
 }
 
 const DefaultProps = {
-  emailForm: emailFormDefault,
+  emailForm: <EmailFormDefault />,
 }
 
 const PreFooter = ({ emailForm }: Props) => (


### PR DESCRIPTION
The website's version of aragon-ui doesn't seem to have this problem.

Anyhow, React will complain since the default email form isn't invoked as a component and not show it:

<img width="974" alt="screen shot 2018-01-16 at 9 56 07 pm" src="https://user-images.githubusercontent.com/4166642/35023466-c24c421c-fb08-11e7-8096-06e823237309.png">
