### PR TITLE
Button: support for emphasis + strong mode

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -6,6 +6,8 @@ import { fontStyle } from '../../shared-styles'
 import getPublicUrl, { styledPublicUrl as asset } from '../../public-url'
 import cross from './assets/cross.svg'
 import check from './assets/check.svg'
+import crossWhite from './assets/cross-white.svg'
+import checkWhite from './assets/check-white.svg'
 
 const {
   gradientStart,
@@ -68,8 +70,8 @@ const modeSecondary = css`
 const modeStrong = css`
   ${plainButtonStyles};
   color: ${gradientText};
-  background-image: linear-gradient(130deg, ${gradientStart}, ${gradientEnd});
   ${fontStyle({ size: 'small', weight: 'bold' })};
+  background-image: linear-gradient(130deg, ${gradientStart}, ${gradientEnd});
   &:after {
     background-image: linear-gradient(
       130deg,
@@ -110,11 +112,35 @@ const compactStyle = css`
 const positiveStyle = css`
   padding-left: 34px;
   background: url(${asset(check)}) no-repeat 12px calc(50% - 1px);
+  ${({ mode }) => {
+    if (mode !== 'strong') return ''
+    return css`
+      &, &:active {
+        background-image: url(${asset(checkWhite)});
+        background-color: ${theme.positive};
+      }
+      &:after {
+        background: none;
+      }
+    `
+  }};
 `
 
 const negativeStyle = css`
   padding-left: 30px;
   background: url(${asset(cross)}) no-repeat 10px calc(50% - 1px);
+  ${({ mode }) => {
+    if (mode !== 'strong') return ''
+    return css`
+      &, &:active {
+        background-image: url(${asset(crossWhite)});
+        background-color: ${theme.negative};
+      }
+      &:after {
+        background: none;
+      }
+    `
+  }};
 `
 
 type Mode = 'normal' | 'secondary' | 'strong' | 'outline' | 'text'

--- a/src/components/Button/assets/check-white.svg
+++ b/src/components/Button/assets/check-white.svg
@@ -1,0 +1,1 @@
+<svg width="14" height="10" viewBox="0 0 14 10" xmlns="http://www.w3.org/2000/svg"><path d="M4.176 7.956L12.114 0l1.062 1.062-9 9L0 5.886l1.044-1.062z" fill="#FFF" fill-rule="evenodd"/></svg>

--- a/src/components/Button/assets/cross-white.svg
+++ b/src/components/Button/assets/cross-white.svg
@@ -1,0 +1,1 @@
+<svg width="11" height="11" viewBox="0 0 11 11" xmlns="http://www.w3.org/2000/svg"><path d="M10.476 1.062L6.3 5.238l4.176 4.176-1.062 1.062L5.238 6.3l-4.176 4.176L0 9.414l4.176-4.176L0 1.062 1.062 0l4.176 4.176L9.414 0z" fill="#FFF" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
Example:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/36158/35197700-11b12644-fedb-11e7-9c0c-647d602bb1b6.png">
