### PR TITLE
TableCell / TableHeader: support align

### DIFF
--- a/src/components/Table/TableCell.js
+++ b/src/components/Table/TableCell.js
@@ -1,5 +1,3 @@
-/* @flow */
-import type { Node, ComponentType } from 'react'
 import React from 'react'
 import styled from 'styled-components'
 import theme from '../../theme'
@@ -11,6 +9,7 @@ const StyledTableCell = styled.td`
   padding: 20px;
   background: ${contentBackground};
   border-bottom: 1px solid ${contentBorder};
+  text-align: ${({ align }) => align};
 
   /* First and last cell styling */
   &:first-child {
@@ -41,25 +40,23 @@ const StyledTableCell = styled.td`
 const StyledTableCellContent = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: ${({ align }) =>
+    align === 'right' ? 'flex-end' : 'space-between'};
 `
 
-type Props = {
-  children: Node,
-  contentContainer: ComponentType<*>,
-}
-
 const DefaultProps = {
+  align: 'left',
   contentContainer: StyledTableCellContent,
 }
 
 const TableCell = ({
   children,
   contentContainer: Container,
+  align,
   ...props
-}: Props) => (
-  <StyledTableCell {...props}>
-    <Container>{children}</Container>
+}) => (
+  <StyledTableCell align={align} {...props}>
+    <Container align={align}>{children}</Container>
   </StyledTableCell>
 )
 

--- a/src/components/Table/TableHeader.js
+++ b/src/components/Table/TableHeader.js
@@ -1,25 +1,28 @@
-/* @flow */
 import React from 'react'
 import styled from 'styled-components'
 import theme from '../../theme'
 import Text from '../Text/Text'
 
 const StyledTableHeader = styled.th`
-  padding-left: 21px;
+  padding-left: ${({align}) => align === 'left'? '21px' : '0'};
+  padding-right: ${({align}) => align === 'right'? '21px' : '0'};
   text-align: left;
   font-weight: normal;
+  text-align: ${({ align }) => align};
 `
 
-type Props = {
-  title: string,
+const DefaultProps = {
+  align: 'left',
 }
 
-const TableHeader = ({ title, ...props }: Props) => (
-  <StyledTableHeader {...props}>
+const TableHeader = ({ title, align, ...props }) => (
+  <StyledTableHeader align={align} {...props}>
     <Text.Block color={theme.textSecondary} smallcaps>
       {title}
     </Text.Block>
   </StyledTableHeader>
 )
+
+TableHeader.defaultProps = DefaultProps
 
 export default TableHeader


### PR DESCRIPTION
Add support for `align` on `TableCell` and `TableHeader`.

Also removes references to flow.