### PR TITLE
SidePanel update

### DIFF
--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -9,11 +9,11 @@ import getPublicUrl, { prefixUrl } from '../../public-url'
 
 import close from './assets/close.svg'
 
-export const PANEL_WIDTH = 450
-export const PANEL_OVERFLOW = PANEL_WIDTH * 0.2
-export const PANEL_HIDE_RIGHT = -PANEL_WIDTH * 1.6
-export const HORIZONTAL_PADDING = 30
-export const PANEL_INNER_WIDTH = PANEL_WIDTH - HORIZONTAL_PADDING * 2
+const PANEL_WIDTH = 450
+const PANEL_OVERFLOW = PANEL_WIDTH * 0.2
+const PANEL_HIDE_RIGHT = -PANEL_WIDTH * 1.6
+const HORIZONTAL_PADDING = 30
+const PANEL_INNER_WIDTH = PANEL_WIDTH - HORIZONTAL_PADDING * 2
 
 const StyledSidePanel = styled.div`
   position: fixed;

--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -9,9 +9,11 @@ import getPublicUrl, { prefixUrl } from '../../public-url'
 
 import close from './assets/close.svg'
 
-const PANEL_WIDTH = 400
-const PANEL_OVERFLOW = PANEL_WIDTH * 0.2
-const PANEL_HIDE_RIGHT = -PANEL_WIDTH * 1.6
+export const PANEL_WIDTH = 450
+export const PANEL_OVERFLOW = PANEL_WIDTH * 0.2
+export const PANEL_HIDE_RIGHT = -PANEL_WIDTH * 1.6
+export const HORIZONTAL_PADDING = 30
+export const PANEL_INNER_WIDTH = PANEL_WIDTH - HORIZONTAL_PADDING * 2
 
 const StyledSidePanel = styled.div`
   position: fixed;
@@ -37,8 +39,8 @@ const StyledPanel = styled.aside`
   display: flex;
   flex-direction: column;
   width: ${PANEL_WIDTH + PANEL_OVERFLOW}px;
-  padding-right: ${30 + PANEL_OVERFLOW}px;
-  padding-left: 30px;
+  padding-right: ${HORIZONTAL_PADDING + PANEL_OVERFLOW}px;
+  padding-left: ${HORIZONTAL_PADDING}px;
   height: 100%;
   background: white;
   position: absolute;
@@ -60,7 +62,7 @@ const StyledPanelCloseButton = styled.button`
     position: absolute;
     padding: 20px;
     top: 0;
-    right: -30px;
+    right: -${HORIZONTAL_PADDING}px;
     cursor: pointer;
     background: none;
     border: 0;
@@ -144,4 +146,12 @@ SidePanel.defaultProps = {
   blocking: false,
 }
 
-export default getPublicUrl(SidePanel)
+const WrappedSidePanel = getPublicUrl(SidePanel)
+
+WrappedSidePanel.PANEL_WIDTH = PANEL_WIDTH
+WrappedSidePanel.PANEL_OVERFLOW = PANEL_OVERFLOW
+WrappedSidePanel.PANEL_HIDE_RIGHT = PANEL_HIDE_RIGHT
+WrappedSidePanel.HORIZONTAL_PADDING = HORIZONTAL_PADDING
+WrappedSidePanel.PANEL_INNER_WIDTH = PANEL_INNER_WIDTH
+
+export default WrappedSidePanel

--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -95,10 +95,16 @@ class SidePanel extends React.Component {
       this.handleClose()
     }
   }
+  handleMotionRest = () => {
+    this.props.onTransitionEnd(this.props.opened)
+  }
   render() {
     const { children, title, opened, blocking, publicUrl } = this.props
     return (
-      <Motion style={{ progress: spring(Number(opened), springConf('slow')) }}>
+      <Motion
+        style={{ progress: spring(Number(opened), springConf('slow')) }}
+        onRest={this.handleMotionRest}
+      >
         {({ progress }) => {
           const styles = motionStyles(progress)
           return (
@@ -139,11 +145,13 @@ SidePanel.propTypes = {
   blocking: PropTypes.bool,
   onClose: PropTypes.func,
   publicUrl: PropTypes.string.isRequired,
+  onTransitionEnd: PropTypes.func,
 }
 
 SidePanel.defaultProps = {
   opened: true,
   blocking: false,
+  onTransitionEnd: () => {},
 }
 
 const WrappedSidePanel = getPublicUrl(SidePanel)


### PR DESCRIPTION
Some additions to the SidePanel component:

1. Export the dimensions − useful to position inner components.
2. Add a `onTransitionEnd` callback − useful to update inner components after the panel opens or closes.
