### PR TITLE
SidePanel: add default onClose

### DIFF
--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -151,6 +151,7 @@ SidePanel.propTypes = {
 SidePanel.defaultProps = {
   opened: true,
   blocking: false,
+  onClose: () => {},
   onTransitionEnd: () => {},
 }
 


### PR DESCRIPTION
Alternatively we could check that `onClose` is available [here](https://github.com/aragon/aragon-ui/compare/side-panel-add-default-onclose?expand=1#diff-f5eebddeafb17884215204484008fd4eR90)