### PR TITLE
Allow IconInfos to break their title and body into multiple lines

### DIFF
--- a/src/components/Info/IconInfo.js
+++ b/src/components/Info/IconInfo.js
@@ -13,13 +13,15 @@ const Icon = styled.span`
 
 const Title = styled.div`
   color: ${theme.textSecondary};
-  margin-top: 2px;
-  white-space: nowrap;
+  margin-bottom: 2px;
+  display: flex;
+  align-items: center;
   ${font({ size: 'small' })};
 `
 
 const TitlelessBody = styled.div`
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 `
 
 const IconInfo = ({ children, icon, title, ...props }) => {

--- a/src/components/Info/Info.js
+++ b/src/components/Info/Info.js
@@ -23,6 +23,7 @@ const Main = styled.section`
   background: ${({ background }) => background};
   padding: 15px;
   border-radius: 3px;
+  word-wrap: break-word;
 `
 
 const Title = styled.h1`


### PR DESCRIPTION
<img width="291" alt="screen shot 2018-02-14 at 11 55 31 pm" src="https://user-images.githubusercontent.com/4166642/36304658-baf3d64a-1310-11e8-9d7a-366f6b1e4556.png">

Also puts the title's margin to the bottom to be closer to designs.