### PR TITLE
React: upgrade to 16.2.0

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -8,8 +8,8 @@
     "markdown-it": "^8.4.0",
     "markdown-it-anchor": "^4.0.0",
     "prismjs": "^1.8.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "styled-components": "^2.2.3"
   },
   "scripts": {

--- a/gallery/yarn.lock
+++ b/gallery/yarn.lock
@@ -3434,9 +3434,9 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+react-dom@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -3455,9 +3455,9 @@ react-onclickout@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/react-onclickout/-/react-onclickout-2.0.8.tgz#d178b13fb87a481356761b454aa60df7069b2da4"
 
-react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "start": "cd gallery && npm start"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "styled-components": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Allows `aragon-ui` to safely use fragments.

I think most of the dependents are already using 16.2.0, so this shouldn't cause any issues.