### PR TITLE
Add observer HOC for connecting to RxJS

### DIFF
--- a/gallery/package.json
+++ b/gallery/package.json
@@ -10,6 +10,7 @@
     "prismjs": "^1.8.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "rxjs": "^5.5.6",
     "styled-components": "^2.2.3"
   },
   "scripts": {

--- a/gallery/src/pages/PageObserve.js
+++ b/gallery/src/pages/PageObserve.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Subject } from 'rxjs'
+import { observe, Badge, Button } from '@aragon/ui'
+
+import Page from 'comps/Page/Page'
+import readme from 'ui-src/rxjs/observe.md'
+
+const Container = styled.div`
+  padding: 20px;
+`
+const LaunchButton = styled(Button).attrs({
+  mode: 'strong',
+})`
+  margin-top: 10px;
+`
+
+class PageObserve extends React.Component {
+  constructor() {
+    super()
+    this.observable = new Subject()
+  }
+  launchEvents = () => {
+    ;[1, 2, 3].forEach(val => {
+      setTimeout(() => {
+        this.observable.next(val)
+      }, val * 500)
+    })
+  }
+  render() {
+    const { title } = this.props
+    return (
+      <Page title={title} readme={readme}>
+        <Page.Demo opaque>
+          <Container>
+            <Observed observable={this.observable} propValue={0} />
+            <LaunchButton onClick={this.launchEvents}>
+              Launch RxJS events
+            </LaunchButton>
+          </Container>
+        </Page.Demo>
+      </Page>
+    )
+  }
+}
+
+const Receiver = ({ propValue, value }) => (
+  <div>
+    <p>
+      Current observed value: <Badge>{value}</Badge>
+    </p>
+    <p>
+      Current passed prop value: <Badge>{propValue}</Badge>
+    </p>
+  </div>
+)
+const Observed = observe(
+  Receiver,
+  observable =>
+    observable.map(value => {
+      return { value }
+    }),
+  { value: 0 }
+)
+
+export default PageObserve

--- a/gallery/src/pages/PageObserve.js
+++ b/gallery/src/pages/PageObserve.js
@@ -55,12 +55,11 @@ const Receiver = ({ propValue, value }) => (
   </div>
 )
 const Observed = observe(
-  Receiver,
   observable =>
     observable.map(value => {
       return { value }
     }),
   { value: 0 }
-)
+)(Receiver)
 
 export default PageObserve

--- a/gallery/src/render-readme.js
+++ b/gallery/src/render-readme.js
@@ -26,7 +26,9 @@ const splitIntro = html => {
 
   const children = [...container.childNodes]
   const docIndex = children.findIndex(
-    elt => elt.tagName === 'H2' && elt.textContent === 'Properties'
+    elt =>
+      elt.tagName === 'H2' &&
+      (elt.textContent === 'Properties' || elt.textContent === 'Signature')
   )
 
   if (children[0].tagName === 'H1') {

--- a/gallery/src/routes.js
+++ b/gallery/src/routes.js
@@ -27,6 +27,9 @@ import PageCard from './pages/PageCard'
 import PageEmptyStateCard from './pages/PageEmptyStateCard'
 import PageTable from './pages/PageTable'
 
+// RxJS
+import PageObserve from './pages/PageObserve'
+
 const preparePage = ([comp, name, path]) => ({
   comp,
   name,
@@ -72,6 +75,12 @@ export const PAGE_GROUPS = [
       [PageCircleGraph, 'CircleGraph', '/circle-graph'],
       [PageCountdown, 'Countdown', '/countdown'],
       [PageInfo, 'Info', '/info'],
+    ].map(preparePage),
+  },
+  {
+    name: 'RxJS',
+    pages: [
+      [PageObserve, 'Observe', '/observe'],
     ].map(preparePage),
   },
 ]

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "babel-plugin-external-helpers": "^6.22.0",
     "date-fns": "^2.0.0-alpha.7",
     "prop-types": "^15.6.0",
+    "react-display-name": "^0.2.3",
     "react-motion": "^0.5.2",
     "react-onclickout": "^2.0.8"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable prettier/prettier */
 
 export * from './icons'
+export * from './rxjs'
 export { default as theme, themeDark, brand, colors } from './theme'
 export { font, grid, spring, breakpoint, BreakPoint, unselectable } from './utils/styles'
 export { formatIntegerRange } from './utils/format'

--- a/src/rxjs/README.md
+++ b/src/rxjs/README.md
@@ -1,0 +1,4 @@
+RxJS
+====
+
+Optional additional components for use with RxJS.

--- a/src/rxjs/index.js
+++ b/src/rxjs/index.js
@@ -1,0 +1,1 @@
+export { default as observe } from './observe'

--- a/src/rxjs/observe.js
+++ b/src/rxjs/observe.js
@@ -1,0 +1,62 @@
+import React from 'react'
+
+// Higher-order component for convenient subscriptions to RxJS observables
+const observe = (Component, observe, initialState = {}) => {
+  return class extends React.Component {
+    static displayName = `Observe(${Component.displayName ||
+      Component.name ||
+      'Component'})`
+    static propTypes = {
+      observable: ({ observable }, _, componentName) => {
+        if (observable && typeof observable.subscribe !== 'function') {
+          throw new Error(
+            `Invalid prop \`observable\` supplied to \`${componentName}\` ` +
+              '(wrapped by `observe()`). ' +
+              '`observable` must be an RxJS Observable-like object. ' +
+              `Given ${observable} instead.`
+          )
+        }
+      },
+    }
+    state = initialState
+    componentDidMount() {
+      this.subscribe(this.props.observable)
+    }
+    componentWillReceiveProps({ observable: nextObservable }) {
+      const { observable } = this.props
+      // If a new observable gets passed in, unsubscribe from the old and subscribe to the new
+      if (nextObservable !== observable) {
+        this.unsubscribe()
+        this.subscribe(nextObservable)
+      }
+    }
+    componentWillUnmount() {
+      this.unsubscribe()
+    }
+    subscribe = observable => {
+      if (observable) {
+        this.subscription = observe(observable).subscribe(state => {
+          this.setState(state)
+        })
+      }
+    }
+    unsubscribe = () => {
+      this.subscription && this.subscription.unsubscribe()
+    }
+    render() {
+      const { ...props } = this.props
+      // Don't pass down the given observable
+      delete props.observable
+
+      return (
+        <Component
+          subscription={this.subscription}
+          {...this.state}
+          {...props}
+        />
+      )
+    }
+  }
+}
+
+export default observe

--- a/src/rxjs/observe.js
+++ b/src/rxjs/observe.js
@@ -18,7 +18,7 @@ const observe = (Component, observe, initialState = {}) => {
       },
     }
     state = initialState
-    componentDidMount() {
+    componentWillMount() {
       this.subscribe(this.props.observable)
     }
     componentWillReceiveProps({ observable: nextObservable }) {

--- a/src/rxjs/observe.js
+++ b/src/rxjs/observe.js
@@ -2,8 +2,8 @@ import React from 'react'
 import getDisplayName from 'react-display-name'
 
 // Higher-order component for convenient subscriptions to RxJS observables
-const observe = (Component, observe, initialState = {}) => {
-  return class extends React.Component {
+const observe = (observe, initialState = {}) => Component =>
+  class extends React.Component {
     static displayName = `Observe(${getDisplayName(Component)})`
     static propTypes = {
       observable: ({ observable }, _, componentName) => {
@@ -56,6 +56,5 @@ const observe = (Component, observe, initialState = {}) => {
       )
     }
   }
-}
 
 export default observe

--- a/src/rxjs/observe.js
+++ b/src/rxjs/observe.js
@@ -34,26 +34,22 @@ const observe = (observe, initialState = {}) => Component =>
     }
     subscribe = observable => {
       if (observable) {
-        this.subscription = observe(observable).subscribe(state => {
-          this.setState(state)
+        this.setState({
+          subscription: observe(observable).subscribe(state => {
+            this.setState(state)
+          }),
         })
       }
     }
     unsubscribe = () => {
-      this.subscription && this.subscription.unsubscribe()
+      this.state.subscription && this.state.subscription.unsubscribe()
     }
     render() {
       const { ...props } = this.props
       // Don't pass down the given observable
       delete props.observable
 
-      return (
-        <Component
-          subscription={this.subscription}
-          {...this.state}
-          {...props}
-        />
-      )
+      return <Component {...this.state} {...props} />
     }
   }
 

--- a/src/rxjs/observe.js
+++ b/src/rxjs/observe.js
@@ -18,7 +18,7 @@ const observe = (observe, initialState = {}) => Component =>
       },
     }
     state = initialState
-    componentWillMount() {
+    componentDidMount() {
       this.subscribe(this.props.observable)
     }
     componentWillReceiveProps({ observable: nextObservable }) {

--- a/src/rxjs/observe.js
+++ b/src/rxjs/observe.js
@@ -1,11 +1,10 @@
 import React from 'react'
+import getDisplayName from 'react-display-name'
 
 // Higher-order component for convenient subscriptions to RxJS observables
 const observe = (Component, observe, initialState = {}) => {
   return class extends React.Component {
-    static displayName = `Observe(${Component.displayName ||
-      Component.name ||
-      'Component'})`
+    static displayName = `Observe(${getDisplayName(Component)})`
     static propTypes = {
       observable: ({ observable }, _, componentName) => {
         if (observable && typeof observable.subscribe !== 'function') {

--- a/src/rxjs/observe.md
+++ b/src/rxjs/observe.md
@@ -4,7 +4,7 @@ A HOC for convenient subscriptions to RxJS observables.
 
 `observe(observe, initialState = {}) -> (Component) -> ObservedComponent`
 
-Automatically subscribes to the Observable returned by `observe`, passing down its state values as props to the given `Component`.
+Automatically subscribes to the `Observable` returned by `observe`, passing down its state values as props to the given `Component`.
 
 ## Usage
 
@@ -43,11 +43,11 @@ const Observed = observe(
 
 ## Signature
 
-`observe(observe, initialState = {}) -> (Component) -> ObservedComponent`
+`observe(observeFn, initialState = {}) -> (Component) -> ObservedComponent`
 
 - `Component`: Any `React.Node`
-- `observe`: A function that receives the Observable as input. Must return an Observable whose event values will be used as the passed down state
-- `initialState: The initial state to use
+- `observeFn`: A function (`Observable -> Observable`) that receives the `Observable` as input. Must return an `Observable` whose streamed values will be passed down as destructured props.
+- `initialState: The initial state to pass down as destructured props
 
 ## `ObservedComponent`'s Properties
 
@@ -55,19 +55,21 @@ const Observed = observe(
 
 - Type: `RxJS.Observable`
 
-The Observable to be used in `observe`
+The `Observable` to be used in `observe`. Can be initially empty.
 
-## `ObservedComponent`'s Injected Properties to `Component`
+This `Observable` is modifiable while the component is still mounted. The component will automatically unsubscribe from the old `Observable` and subscribe to the new `Observable` using the `observeFn`.
+
+## `Component`'s Injected Properties
 
 ### `{...state}`
 
-Any state returned by `observe`'s Observable is spread and added to `Component`'s props.
+Any state streamed by `observeFn`'s returned `Observable` is destructured and added to `Component`'s props.
 
 ### `subscription`
 
 - Type: `RxJS.Subscription`
 
-The Subscription object to `observe`'s Observable (useful if you'd like to unsubscribe prematurely).
+The `Subscription` of `observeFn`'s returned `Observable` (useful if `Component` would like to unsubscribe prematurely). Note that this will not be injected until an `Observable` is passed into the wrapped component.
 
 ### `*`
 

--- a/src/rxjs/observe.md
+++ b/src/rxjs/observe.md
@@ -2,9 +2,9 @@
 
 A HOC for convenient subscriptions to RxJS observables.
 
-`observe(Component, observe, initialState = {}) -> ObservedComponent`
+`observe(observe, initialState = {}) -> (Component) -> ObservedComponent`
 
-Automatically subscribes to the resulting Observable returned by `observe`, passing down its state values as props to the given `Component`.
+Automatically subscribes to the Observable returned by `observe`, passing down its state values as props to the given `Component`.
 
 ## Usage
 
@@ -34,17 +34,16 @@ const ReceivingComponent = ({ propValue, value }) => (
 )
 
 const Observed = observe(
-  ReceivingComponent,
   observable => observable.map(value => {
      return { value }
   }),
   { value: 0 }
-)
+)(ReceivingComponent)
 ```
 
 ## Signature
 
-`observe(Component, observe, initialState = {}) -> ObservedComponent`
+`observe(observe, initialState = {}) -> (Component) -> ObservedComponent`
 
 - `Component`: Any `React.Node`
 - `observe`: A function that receives the Observable as input. Must return an Observable whose event values will be used as the passed down state
@@ -58,7 +57,7 @@ const Observed = observe(
 
 The Observable to be used in `observe`
 
-## `ObservedComponent`'s Added Properties to `Component`
+## `ObservedComponent`'s Injected Properties to `Component`
 
 ### `{...state}`
 

--- a/src/rxjs/observe.md
+++ b/src/rxjs/observe.md
@@ -1,0 +1,75 @@
+# observe
+
+A HOC for convenient subscriptions to RxJS observables.
+
+`observe(Component, observe, initialState = {}) -> ObservedComponent`
+
+Automatically subscribes to the resulting Observable returned by `observe`, passing down its state values as props to the given `Component`.
+
+## Usage
+
+```jsx
+import { observe } from '@aragon/ui'
+import { Observable } from 'rxjs'
+
+class App extends React.Component {
+  constructor() {
+    super()
+    this.observable = Observable.from([1, 2, 3])
+  }
+  render() {
+    <Observed observable={this.observable} propValue={0} />
+  }
+}
+
+const ReceivingComponent = ({ propValue, value }) => (
+  <div>
+    <p>
+      The observable's current value: {value}
+    </p>
+    <p>
+      The passed down prop's value: {propValue}
+    </p>
+  </div>
+)
+
+const Observed = observe(
+  ReceivingComponent,
+  observable => observable.map(value => {
+     return { value }
+  }),
+  { value: 0 }
+)
+```
+
+## Signature
+
+`observe(Component, observe, initialState = {}) -> ObservedComponent`
+
+- `Component`: Any `React.Node`
+- `observe`: A function that receives the Observable as input. Must return an Observable whose event values will be used as the passed down state
+- `initialState: The initial state to use
+
+## `ObservedComponent`'s Properties
+
+### `observable`
+
+- Type: `RxJS.Observable`
+
+The Observable to be used in `observe`
+
+## `ObservedComponent`'s Added Properties to `Component`
+
+### `{...state}`
+
+Any state returned by `observe`'s Observable is spread and added to `Component`'s props.
+
+### `subscription`
+
+- Type: `RxJS.Subscription`
+
+The Subscription object to `observe`'s Observable (useful if you'd like to unsubscribe prematurely).
+
+### `*`
+
+All other props will be passed down to `Component`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,6 +3494,10 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-display-name@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.3.tgz#f50204d430c9ca819bc0bade0306e9175d8d1987"
+
 react-media@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/react-media/-/react-media-1.6.1.tgz#84e7986a92356b106dca026363f8f5c88054fe72"


### PR DESCRIPTION
Adds a convenience HOC for connecting a component to an RxJS observable.

Passes down a transformation of the observable's values as props.