### PR TITLE
Button.Anchor: extend its styles with styled()

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -209,7 +209,7 @@ const StyledButton = styled.button.attrs({ type: 'button' })`
 
 const Button = PublicUrl.hocWrap(StyledButton)
 const Anchor = PublicUrl.hocWrap(
-  StyledButton.withComponent(SafeLink).extend`
+  styled(StyledButton.withComponent(SafeLink))`
     ${unselectable};
     display: inline-block;
     text-decoration: none;


### PR DESCRIPTION
Fix the settings buttons in aragon/aragon.