### PR TITLE
Dropdown items type

### DIFF
--- a/devbox/apps/DropDown.js
+++ b/devbox/apps/DropDown.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import styled from 'styled-components'
+import { AragonApp, DropDown, unselectable } from '@aragon/ui'
+
+const items = ['Strawberry', 'Banana', 'Apple', 'Cherry']
+
+class App extends React.Component {
+  state = { active: 0 }
+  handleChange = index => {
+    this.setState({ active: index })
+  }
+  render() {
+    const { active } = this.state
+    return (
+      <AragonApp publicUrl="/aragon-ui/">
+        <Main>
+          <Container>
+            <DropDown
+              items={items}
+              active={active}
+              onChange={this.handleChange}
+            />
+          </Container>
+        </Main>
+      </AragonApp>
+    )
+  }
+}
+
+const Main = styled.div`
+  ${unselectable};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #fff;
+`
+
+const Container = styled.div`
+  width: 150px;
+`
+
+export default App

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -69,7 +69,7 @@ const DropDownActiveItem = styled(PublicUrl.hocWrap(DropDownItem))`
 
 class DropDown extends React.Component {
   static propTypes = {
-    items: PropTypes.arrayOf(PropTypes.string),
+    items: PropTypes.arrayOf(PropTypes.node),
     wide: PropTypes.bool,
     active: PropTypes.number,
     onChange: PropTypes.func,

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -112,7 +112,7 @@ class DropDown extends React.Component {
             {activeItem}
           </DropDownActiveItem>
           <Transition
-            config={springs.normal}
+            config={springs.swift}
             from={{ scale: 0.98, opacity: 0, enabled: 1 }}
             enter={{ scale: 1, opacity: 1, enabled: 1 }}
             leave={{ scale: 1, opacity: 0, enabled: 0 }}
@@ -123,9 +123,9 @@ class DropDown extends React.Component {
                   <DropDownItems
                     role="listbox"
                     style={{
-                      transform: scale.interpolate(t => `scale(${t},${t})`),
-                      minWidth: wide ? '100%' : '0',
                       opacity,
+                      transform: scale.interpolate(t => `scale3d(${t},${t},1)`),
+                      minWidth: wide ? '100%' : '0',
                     }}
                   >
                     {items.length

--- a/src/utils/styles/spring.js
+++ b/src/utils/styles/spring.js
@@ -10,8 +10,11 @@ export const springs = {
   // Slow spring, can be used to move large things (e.g. a side panel).
   lazy: { tension: 50, friction: 10 },
 
-  // Medium speed spring, can be used to move small objects
+  // Medium speed spring, can be used to move small objects.
   smooth: { tension: 120, friction: 12 },
+
+  // Fast speed spring, for actions that need to feel almost instant.
+  swift: { tension: 400, friction: 28 },
 
   // These springs (slow, normal, fast) were originally created for
   // react-motion. While they can be used with react-spring, their use is not
@@ -20,7 +23,6 @@ export const springs = {
   slow: { tension: 150, friction: 18 },
   normal: { tension: 190, friction: 22 },
   fast: { tension: 220, friction: 24 },
-  swift: { tension: 400, friction: 28 },
 }
 
 // Convert to react-motion springs:


### PR DESCRIPTION
Allow nodes in `DropDown items`, so we can use components:

<img width="426" alt="image" src="https://user-images.githubusercontent.com/36158/45026052-0943e580-b035-11e8-86f7-fdb87f1b24a5.png">

Also:

- Make the transition faster.
- Add a devbox app.