### PR TITLE
Update wrapper (App & View) heights

### DIFF
--- a/src/components/AragonApp/AppView.js
+++ b/src/components/AragonApp/AppView.js
@@ -29,7 +29,7 @@ class AppView extends React.Component {
 
 const Main = styled.div`
   display: flex;
-  height: 100vh;
+  height: 100%;
   flex-direction: column;
   align-items: stretch;
   justify-content: stretch;

--- a/src/components/AragonApp/AragonApp.js
+++ b/src/components/AragonApp/AragonApp.js
@@ -8,8 +8,11 @@ import { ensureTrailingSlash } from '../../utils/url'
 import logo from './assets/logo-background.svg'
 
 const StyledAragonApp = styled.main`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
   min-width: 320px;
-  min-height: 100vh;
   background-color: ${theme.mainBackground};
   background-image: ${({ backgroundLogo }) =>
     backgroundLogo ? css`url(${PublicUrl.styledUrl(logo)})` : 'none'};


### PR DESCRIPTION
With the addition of a top-level banner [here](https://github.com/aragon/aragon/pull/371) scrollable wrappers using `100vh` were not rendering the correct height. These changes update the rules and the content scrolls correctly.