### PR TITLE
Button size

### DIFF
--- a/devbox/.babelrc
+++ b/devbox/.babelrc
@@ -1,7 +1,7 @@
 {
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
   "plugins": [
-    ["styled-components", { "displayName": true }],
-    ["transform-class-properties"]
-  ],
-  "presets": [["env", "react", "stage-2"]]
+    "@babel/plugin-proposal-class-properties",
+    ["styled-components", { "displayName": true }]
+  ]
 }

--- a/devbox/apps/Button.js
+++ b/devbox/apps/Button.js
@@ -8,7 +8,71 @@ const EMPHASES = ['none', 'positive', 'negative']
 const DISABLED = [false, true]
 
 class App extends React.Component {
+  renderAllButtons() {
+    return EMPHASES.map((emphasis, emphasisIndex) => (
+      <div key={[emphasisIndex].join('')} className="emphasis">
+        <h2>
+          <Text size="xlarge">
+            emphasis=
+            {emphasis}
+          </Text>
+        </h2>
+        <div>
+          {DISABLED.map((disabled, disabledIndex) =>
+            SIZES.map((size, sizeIndex) => (
+              <div
+                key={[emphasisIndex, disabledIndex, sizeIndex].join('')}
+                className="row"
+              >
+                {MODES.map((mode, modeIndex) => (
+                  <span
+                    key={[
+                      emphasisIndex,
+                      disabledIndex,
+                      sizeIndex,
+                      modeIndex,
+                    ].join('')}
+                  >
+                    <Button
+                      size={size}
+                      mode={mode}
+                      emphasis={emphasis}
+                      disabled={disabled}
+                    >
+                      {mode}
+                      {disabled && size !== 'normal' ? ` (${size} & off)` : ''}
+                      {disabled && size === 'normal' ? ` (off)` : ''}
+                      {!disabled && size !== 'normal' ? ` (${size})` : ''}
+                    </Button>
+                  </span>
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    ))
+  }
+  renderSomeButtons() {
+    return (
+      <div style={{ padding: '100px 0' }}>
+        {['normal', 'strong', 'secondary'].map(mode => (
+          <div className="row" key={mode}>
+            {SIZES.map(size => (
+              <span key={mode + size}>
+                <Button mode={mode} size={size}>
+                  {size}
+                </Button>
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  }
   render() {
+    // const buttons = this.renderSomeButtons()
+    const buttons = this.renderAllButtons()
     return (
       <AragonApp publicUrl="/aragon-ui/">
         <Main>
@@ -16,50 +80,7 @@ class App extends React.Component {
             <h1>
               <Text size="xxlarge">Button variations</Text>
             </h1>
-            {EMPHASES.map((emphasis, emphasisIndex) => (
-              <div key={[emphasisIndex].join('')} className="emphasis">
-                <h2>
-                  <Text size="xlarge">emphasis={emphasis}</Text>
-                </h2>
-                <div>
-                  {DISABLED.map((disabled, disabledIndex) =>
-                    SIZES.map((size, sizeIndex) => (
-                      <div
-                        key={[emphasisIndex, disabledIndex, sizeIndex].join('')}
-                        className="row"
-                      >
-                        {MODES.map((mode, modeIndex) => (
-                          <span
-                            key={[
-                              emphasisIndex,
-                              disabledIndex,
-                              sizeIndex,
-                              modeIndex,
-                            ].join('')}
-                          >
-                            <Button
-                              size={size}
-                              mode={mode}
-                              emphasis={emphasis}
-                              disabled={disabled}
-                            >
-                              {mode}
-                              {disabled && size !== 'normal'
-                                ? ` (${size} & off)`
-                                : ''}
-                              {disabled && size === 'normal' ? ` (off)` : ''}
-                              {!disabled && size !== 'normal'
-                                ? ` (${size})`
-                                : ''}
-                            </Button>
-                          </span>
-                        ))}
-                      </div>
-                    ))
-                  )}
-                </div>
-              </div>
-            ))}
+            {buttons}
           </Container>
         </Main>
       </AragonApp>

--- a/devbox/apps/Button.js
+++ b/devbox/apps/Button.js
@@ -1,0 +1,108 @@
+import React from 'react'
+import styled from 'styled-components'
+import { AragonApp, Button, Text, theme } from '@aragon/ui'
+
+const MODES = ['normal', 'secondary', 'strong', 'outline', 'text']
+const SIZES = ['normal', 'small', 'mini']
+const EMPHASES = ['none', 'positive', 'negative']
+const DISABLED = [false, true]
+
+class App extends React.Component {
+  render() {
+    return (
+      <AragonApp publicUrl="/aragon-ui/">
+        <Main>
+          <Container>
+            <h1>
+              <Text size="xxlarge">Button variations</Text>
+            </h1>
+            {EMPHASES.map((emphasis, emphasisIndex) => (
+              <div key={[emphasisIndex].join('')} className="emphasis">
+                <h2>
+                  <Text size="xlarge">emphasis={emphasis}</Text>
+                </h2>
+                <div>
+                  {DISABLED.map((disabled, disabledIndex) =>
+                    SIZES.map((size, sizeIndex) => (
+                      <div
+                        key={[emphasisIndex, disabledIndex, sizeIndex].join('')}
+                        className="row"
+                      >
+                        {MODES.map((mode, modeIndex) => (
+                          <span
+                            key={[
+                              emphasisIndex,
+                              disabledIndex,
+                              sizeIndex,
+                              modeIndex,
+                            ].join('')}
+                          >
+                            <Button
+                              size={size}
+                              mode={mode}
+                              emphasis={emphasis}
+                              disabled={disabled}
+                            >
+                              {mode}
+                              {disabled && size !== 'normal'
+                                ? ` (${size} & off)`
+                                : ''}
+                              {disabled && size === 'normal' ? ` (off)` : ''}
+                              {!disabled && size !== 'normal'
+                                ? ` (${size})`
+                                : ''}
+                            </Button>
+                          </span>
+                        ))}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            ))}
+          </Container>
+        </Main>
+      </AragonApp>
+    )
+  }
+}
+
+const Main = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  background: hsl(200, 30%, 85%);
+`
+
+const Container = styled.div`
+  min-height: 0;
+  h1 {
+    margin: 40px 0;
+    text-align: center;
+  }
+  h2 {
+    margin: 20px 0;
+    text-align: center;
+  }
+  .emphasis {
+    padding: 20px 0 80px;
+  }
+  .row {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 20px;
+    > span {
+      margin-left: 10px;
+    }
+  }
+`
+
+export default App

--- a/devbox/index.js
+++ b/devbox/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 // import App from './apps/LinkedSliders'
 // import App from './apps/RadioButton'
 // import App from './apps/SidePanel'
-import App from './apps/NavigationBar'
+// import App from './apps/NavigationBar'
+import App from './apps/Button'
 
 ReactDOM.render(<App />, document.getElementById('app'))

--- a/devbox/package.json
+++ b/devbox/package.json
@@ -4,22 +4,20 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "sync-assets":
-      "mkdir -p dist && rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" dist/aragon-ui",
+    "sync-assets": "mkdir -p dist && rsync -rtu \"$(dirname $(node -p 'require.resolve(\"@aragon/ui\")'))/\" dist/aragon-ui",
     "start": "npm run sync-assets && parcel index.html"
   },
   "dependencies": {
     "@aragon/ui": "file:..",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
-    "react-motion": "^0.5.2",
-    "styled-components": "^3.2.6"
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "styled-components": "^3.4.10"
   },
   "devDependencies": {
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
-    "parcel-bundler": "^1.8.1"
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "parcel-bundler": "^1.10.2"
   }
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -129,45 +129,65 @@ const modeText = css`
   }
 `
 
-const compactStyle = css`
+const smallStyle = css`
   padding: ${({ mode }) => (mode === 'outline' ? '4px 14px' : '5px 15px')};
 `
 
-const positiveStyle = css`
-  padding-left: 34px;
-  background: url(${styledUrl(check)}) no-repeat 12px calc(50% - 1px);
+const miniStyle = css`
+  padding: ${({ mode }) => (mode === 'outline' ? '1px 11px' : '2px 12px')};
+  ${font({ size: 'small' })};
+`
+
+const getEmphasisStyle = ({
+  emphasisColor,
+  icon,
+  iconLight,
+  iconX = '12px',
+  iconY = 'calc(50% - 1px)',
+  iconWidth = '34px',
+}) => css`
+  padding-left: ${iconWidth};
+  background-image: url(${styledUrl(icon)});
+  background-position: ${iconX} ${iconY};
+  background-repeat: no-repeat;
   ${({ mode }) => {
-    if (mode !== 'strong') return ''
-    return css`
-      &,
-      &:active {
-        background-image: url(${styledUrl(checkWhite)});
-        background-color: ${theme.positive};
-      }
-      &:after {
-        background: none;
-      }
-    `
+    if (mode === 'normal') {
+      return css`
+        &,
+        &:active {
+          background-image: url(${styledUrl(icon)});
+        }
+      `
+    }
+    if (mode === 'strong') {
+      return css`
+        &,
+        &:active {
+          background-image: url(${styledUrl(iconLight)});
+          background-color: ${emphasisColor};
+        }
+        &:after {
+          background: none;
+        }
+      `
+    }
+    return ''
   }};
 `
 
-const negativeStyle = css`
-  padding-left: 30px;
-  background: url(${styledUrl(cross)}) no-repeat 10px calc(50% - 1px);
-  ${({ mode }) => {
-    if (mode !== 'strong') return ''
-    return css`
-      &,
-      &:active {
-        background-image: url(${styledUrl(crossWhite)});
-        background-color: ${theme.negative};
-      }
-      &:after {
-        background: none;
-      }
-    `
-  }};
-`
+const positiveStyle = getEmphasisStyle({
+  emphasisColor: theme.positive,
+  icon: check,
+  iconLight: checkWhite,
+})
+
+const negativeStyle = getEmphasisStyle({
+  emphasisColor: theme.negative,
+  icon: cross,
+  iconLight: crossWhite,
+  iconX: '10px',
+  iconWidth: '30px',
+})
 
 const StyledButton = styled.button.attrs({ type: 'button' })`
   width: ${({ wide }) => (wide ? '100%' : 'auto')};
@@ -198,7 +218,11 @@ const StyledButton = styled.button.attrs({ type: 'button' })`
     return modeNormal
   }};
 
-  ${({ compact }) => (compact ? compactStyle : '')};
+  ${({ compact, size }) => {
+    if (size === 'small' || compact) return smallStyle
+    if (size === 'mini') return miniStyle
+    return ''
+  }};
 
   ${({ emphasis }) => {
     if (emphasis === 'positive') return positiveStyle

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -50,12 +50,30 @@ const App = () => (
 )
 ```
 
-### `compact`
+### `size`
+
+- Type: `String`
+- Values: `normal`, `small` or `mini`.
+- Default: `normal`
+
+Use this property to change the size of the button.
+
+#### Example:
+
+```jsx
+const MyButton = () => (
+  <Button size="small">Accept</Button>
+)
+```
+
+### `compact` (deprecated)
 
 - Type: `Boolean`
 - Default: `false`
 
-Set to true to obtain a button that contains less padding than normal buttons.
+Set to `true` to obtain a button that contains less padding than normal buttons.
+
+It is the equivalent of setting `size` to `small`. This prop is deprecated, please use `size` instead.
 
 #### Example:
 


### PR DESCRIPTION
A smaller button size was needed:

<p align="center">
<img width="340" alt="image" src="https://user-images.githubusercontent.com/36158/46821774-963f3480-cd81-11e8-9685-e191f1669732.png">
</p>


This PR introduces a new prop, `size`, that can be set to `normal` (default), `small` or `mini` (the new size).

- `small` is the equivalent to the `compact` prop, and should be used instead.
- `mini` is the new size, which is smaller than the `small` size.
