### PR TITLE
EmptyStateCard: add prop to disable the action button

### DIFF
--- a/gallery/src/pages/PageEmptyStateCard.js
+++ b/gallery/src/pages/PageEmptyStateCard.js
@@ -16,6 +16,14 @@ const PageEmptyStateCard = ({ title }) => (
             icon={() => <IconHome color="blue" />}
           />
         </div>
+        <div>
+          <EmptyStateCard
+            actionDisabled
+            actionText="Create a new post!"
+            text="You seem to not have any content on your wall."
+            icon={() => <IconHome color="blue" />}
+          />
+        </div>
       </Container>
     </Page.Demo>
   </Page>

--- a/src/components/Card/EmptyStateCard.js
+++ b/src/components/Card/EmptyStateCard.js
@@ -26,6 +26,7 @@ const StyledActionButton = styled(Button)`
 `
 
 const EmptyStateCard = ({
+  actionDisabled,
   actionText,
   onActivate,
   text,
@@ -43,7 +44,11 @@ const EmptyStateCard = ({
         </Text>
       </StyledHeading>
       <Text.Block>{text}</Text.Block>
-      <ActionButton mode="strong" onClick={onActivate}>
+      <ActionButton
+        disabled={actionDisabled}
+        mode="strong"
+        onClick={onActivate}
+      >
         {actionText}
       </ActionButton>
     </section>
@@ -52,6 +57,7 @@ const EmptyStateCard = ({
 
 EmptyStateCard.propTypes = {
   actionButton: PropTypes.node,
+  actionDisabled: PropTypes.bool,
   actionText: PropTypes.string,
   icon: PropTypes.node,
   onActivate: PropTypes.func,

--- a/src/components/Card/EmptyStateCard.md
+++ b/src/components/Card/EmptyStateCard.md
@@ -75,6 +75,20 @@ const App = () => (
 )
 ```
 
+### `actionDisabled`
+
+- Type: `Boolean`
+
+Disable the `actionButton`.
+
+#### Example:
+
+```jsx
+const App = () => (
+  <EmptyStateCard actionDsiabled />
+)
+```
+
 ### `actionText`
 
 - Type: `String`


### PR DESCRIPTION
Useful in cases where the entire app might be disabled.