### PR TITLE
AppView: use 100% rather than 100vh

### DIFF
--- a/src/components/AragonApp/AppView.js
+++ b/src/components/AragonApp/AppView.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import AppBar from './AppBar'
+import { stylingProps } from '../../utils'
 
 class AppView extends React.Component {
   static defaultProps = {
@@ -17,7 +18,7 @@ class AppView extends React.Component {
   render() {
     const { appBar, title, children, padding } = this.props
     return (
-      <Main>
+      <Main {...stylingProps(this)}>
         <Header>{appBar || <AppBar title={title} />}</Header>
         <ScrollWrapper>
           <Content padding={padding}>{children}</Content>
@@ -29,7 +30,7 @@ class AppView extends React.Component {
 
 const Main = styled.div`
   display: flex;
-  height: 100vh;
+  height: 100%;
   flex-direction: column;
   align-items: stretch;
   justify-content: stretch;

--- a/src/utils/components.js
+++ b/src/utils/components.js
@@ -1,0 +1,21 @@
+// Forward some props of an instance to a child element.
+//
+// Usage example:
+//
+//   <Child {...forwardProps(this, ['name', 'style'])}>
+//
+export function forwardProps(instance, names) {
+  return names.reduce((props, name) => {
+    if (instance.props[name]) {
+      props[name] = instance.props[name]
+    }
+    return props
+  }, {})
+}
+
+// Forward the props useful to extend the styles  of the main child of a
+// component, using either styled() or the style attribute. Additionnal names
+// can be passed as a second parameter.
+export function stylingProps(instance, names = []) {
+  return forwardProps(instance, ['style', 'className', ...names])
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@ export * from './date'
 export * from './format'
 export * from './styles'
 export * from './web3'
+export * from './components'
 
 export function noop() {}
 


### PR DESCRIPTION
Also introduces two new utils, `forwardProps()` and `stylingProps()` to respectively forward props to a child element, and to forward the props that allow to extend the styles the main element of a component.