### PR TITLE
Countdown: fix flickr when counting down

### DIFF
--- a/src/components/Countdown/Countdown.js
+++ b/src/components/Countdown/Countdown.js
@@ -52,10 +52,10 @@ class Countdown extends React.Component {
           <Unit>M</Unit>
         </Part>
         <Separator>:</Separator>
-        <Part>
+        <PartSeconds>
           {formatUnit(seconds)}
-          <Unit>S</Unit>
-        </Part>
+          <UnitSeconds>S</UnitSeconds>
+        </PartSeconds>
       </span>
     )
   }
@@ -75,6 +75,18 @@ const Part = styled.span`
   font-size: 15px;
   font-weight: 600;
   color: ${theme.textPrimary};
+`
+
+const PartSeconds = styled(Part)`
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: space-between;
+  min-width: 31px;
+`
+
+const UnitSeconds = styled(Unit)`
+  position: relative;
+  left: -3px;
 `
 
 const Separator = styled.span`


### PR DESCRIPTION
While reviewing #225 I ran into this:

![flickr](https://user-images.githubusercontent.com/3072458/48059454-8b799300-e1b9-11e8-9d4f-a873cd042a22.gif)