### PR TITLE
Make publicUrl a required prop

### DIFF
--- a/src/components/AragonApp/AragonApp.js
+++ b/src/components/AragonApp/AragonApp.js
@@ -21,7 +21,7 @@ class AragonApp extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     backgroundLogo: PropTypes.bool,
-    publicUrl: PropTypes.string,
+    publicUrl: PropTypes.string.isRequired,
     children: PropTypes.node,
     supportLegacyAgents: PropTypes.bool,
   }


### PR DESCRIPTION
Prevent strange errors when publicUrl isn't passed.