### PR TITLE
Fix the “Context.Consumer.Provider is not supported” warning

### DIFF
--- a/src/providers/PublicUrl/PublicUrl.js
+++ b/src/providers/PublicUrl/PublicUrl.js
@@ -5,22 +5,23 @@ import { prefixUrl } from '../../utils/url'
 
 const DEFAULT_URL = ''
 
-const { Provider, Consumer: PublicUrl } = React.createContext(DEFAULT_URL)
+const { Provider, Consumer } = React.createContext(DEFAULT_URL)
 
-const PublicUrlProvider = ({ url, children }) => {
-  return <Provider value={url}>{children}</Provider>
-}
-PublicUrlProvider.propTypes = {
-  url: PropTypes.string,
-  children: PropTypes.node,
+class PublicUrlProvider extends React.Component {
+  static propTypes = {
+    url: PropTypes.string,
+    children: PropTypes.node,
+  }
+  render() {
+    const { url, children } = this.props
+    return <Provider value={url}>{children}</Provider>
+  }
 }
 
 // HOC wrapper
 const hocWrap = Component => {
   const HOC = props => (
-    <PublicUrl>
-      {publicUrl => <Component {...props} publicUrl={publicUrl} />}
-    </PublicUrl>
+    <Consumer>{url => <Component {...props} publicUrl={url} />}</Consumer>
   )
   HOC.displayName = `PublicUrlProvider(${getDisplayName(Component)})`
   return HOC
@@ -29,6 +30,7 @@ const hocWrap = Component => {
 // styled-components utility for URLs
 const styledUrl = url => ({ publicUrl }) => prefixUrl(url, publicUrl)
 
+const PublicUrl = props => <Consumer {...props} />
 PublicUrl.Provider = PublicUrlProvider
 PublicUrl.hocWrap = hocWrap
 PublicUrl.styledUrl = styledUrl


### PR DESCRIPTION
Fixes #232