### PR TITLE
Add Timer component

### DIFF
--- a/devbox/apps/Timer.js
+++ b/devbox/apps/Timer.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import styled from 'styled-components'
+import { AragonApp, Timer } from '@aragon/ui'
+
+const SECONDS = 1000
+const MINUTES = SECONDS * 60
+const HOURS = MINUTES * 60
+const DAYS = HOURS * 24
+
+const now = Date.now()
+
+const timers = [
+  { start: -4 * HOURS },
+  { start: -4 * HOURS, end: 8 * HOURS },
+  { end: 1 * DAYS },
+].map(({ start, end }) => {
+  const timer = {}
+  if (start) timer.start = new Date(now + start)
+  if (end) timer.end = new Date(now + end)
+  return timer
+})
+
+class App extends React.Component {
+  render() {
+    return (
+      <AragonApp publicUrl="/aragon-ui/">
+        <Main>
+          <div>
+            {timers.map(timer => (
+              <div
+                css={`
+                  margin-bottom: 10px;
+                `}
+              >
+                <Timer {...timer} />
+              </div>
+            ))}
+          </div>
+        </Main>
+      </AragonApp>
+    )
+  }
+}
+
+const Main = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+`
+
+export default App

--- a/devbox/apps/Timer.js
+++ b/devbox/apps/Timer.js
@@ -10,13 +10,17 @@ const DAYS = HOURS * 24
 const now = Date.now()
 
 const timers = [
-  { start: -4 * HOURS },
+  { start: -40 * SECONDS },
+  { start: -40 * SECONDS, showEmpty: true },
   { start: -4 * HOURS, end: 8 * HOURS },
   { end: 1 * DAYS },
-].map(({ start, end }) => {
-  const timer = {}
-  if (start) timer.start = new Date(now + start)
-  if (end) timer.end = new Date(now + end)
+  ...['dhms', 'dhm', 'hms', 'hm', 'ms', 'm', 's'].map(format => ({
+    end: 2 * DAYS - 55 * SECONDS,
+    format,
+  })),
+].map(timer => {
+  if (timer.start) timer.start = new Date(now + timer.start)
+  if (timer.end) timer.end = new Date(now + timer.end)
   return timer
 })
 
@@ -26,13 +30,14 @@ class App extends React.Component {
       <AragonApp publicUrl="/aragon-ui/">
         <Main>
           <div>
-            {timers.map(timer => (
+            {timers.map((props, i) => (
               <div
+                key={i}
                 css={`
-                  margin-bottom: 10px;
+                  padding: 5px 0;
                 `}
               >
-                <Timer {...timer} />
+                <Timer {...props} />
               </div>
             ))}
           </div>
@@ -46,7 +51,7 @@ const Main = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  min-height: 100vh;
 `
 
 export default App

--- a/devbox/index.js
+++ b/devbox/index.js
@@ -11,6 +11,7 @@ import TabBar from './apps/TabBar'
 import IdentityBadge from './apps/IdentityBadge'
 import Popover from './apps/Popover'
 import TransactionProgress from './apps/TransactionProgress'
+import Timer from './apps/Timer'
 
 const APPS = {
   LinkedSliders,
@@ -23,6 +24,7 @@ const APPS = {
   IdentityBadge,
   Popover,
   TransactionProgress,
+  Timer,
 }
 
 class Index extends React.Component {

--- a/src/components/Countdown/Countdown.js
+++ b/src/components/Countdown/Countdown.js
@@ -1,113 +1,21 @@
 import React from 'react'
-import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { Redraw } from '../../providers/Redraw'
-import IconTime from '../../icons/components/Time'
-import { difference, formatHtmlDatetime } from '../../utils/date'
-import { unselectable } from '../../utils/styles'
-import { theme } from '../../theme'
-
-const FRAME_EVERY = 1000 / 30 // 30 FPS is enough for a ticker
-
-const formatUnit = v => String(v).padStart(2, '0')
+import Timer from '../Timer/Timer'
 
 class Countdown extends React.Component {
-  static propTypes = {
-    end: PropTypes.instanceOf(Date),
-    removeDaysAndHours: PropTypes.bool,
-  }
   render() {
-    const { end } = this.props
-    return (
-      <Main dateTime={formatHtmlDatetime(end)}>
-        <IconWrapper>
-          <IconTime />
-        </IconWrapper>
-        <Redraw interval={FRAME_EVERY}>{this.renderTime}</Redraw>
-      </Main>
-    )
-  }
-  renderTime = () => {
     const { end, removeDaysAndHours } = this.props
-    const { days, hours, minutes, seconds, totalInSeconds } = difference(
-      end,
-      new Date()
-    )
-    if (totalInSeconds <= 0) {
-      return <TimeOut>Time out</TimeOut>
-    }
-    return (
-      <span>
-        {!removeDaysAndHours && (
-          <React.Fragment>
-            <Part>
-              {formatUnit(days)}
-              <Unit>D</Unit>
-            </Part>
-            <Separator />
-            <Part>
-              {formatUnit(hours)}
-              <Unit>H</Unit>
-            </Part>
-            <Separator>:</Separator>
-          </React.Fragment>
-        )}
-        <Part>
-          {formatUnit(minutes)}
-          <Unit>M</Unit>
-        </Part>
-        <Separator>:</Separator>
-        <PartSeconds>
-          {formatUnit(seconds)}
-          <UnitSeconds>S</UnitSeconds>
-        </PartSeconds>
-      </span>
-    )
+    return <Timer end={end} removeDaysAndHours={removeDaysAndHours} />
   }
 }
 
-const Main = styled.time`
-  white-space: nowrap;
-  ${unselectable()};
-`
+Countdown.propTypes = {
+  end: PropTypes.instanceOf(Date).isRequired,
+  removeDaysAndHours: PropTypes.bool,
+}
 
-const IconWrapper = styled.span`
-  margin-right: 15px;
-`
-
-const Part = styled.span`
-  font-size: 15px;
-  font-weight: 600;
-  color: ${theme.textPrimary};
-`
-
-const PartSeconds = styled(Part)`
-  display: inline-flex;
-  align-items: baseline;
-  justify-content: space-between;
-  min-width: 31px;
-`
-
-const Unit = styled.span`
-  margin-left: 2px;
-  font-size: 12px;
-  color: ${theme.textSecondary};
-`
-
-const UnitSeconds = styled(Unit)`
-  position: relative;
-  left: -3px;
-`
-
-const Separator = styled.span`
-  margin: 0 4px;
-  color: ${theme.textTertiary};
-  font-weight: 400;
-`
-
-const TimeOut = styled.span`
-  font-weight: 600;
-  color: ${theme.textSecondary};
-`
+Countdown.defaultProps = {
+  removeDaysAndHours: false,
+}
 
 export default Countdown

--- a/src/components/Countdown/Countdown.js
+++ b/src/components/Countdown/Countdown.js
@@ -5,7 +5,8 @@ import Timer from '../Timer/Timer'
 class Countdown extends React.Component {
   render() {
     const { end, removeDaysAndHours } = this.props
-    return <Timer end={end} removeDaysAndHours={removeDaysAndHours} />
+    const format = removeDaysAndHours ? 'ms' : 'dhms'
+    return <Timer end={end} format={format} />
   }
 }
 

--- a/src/components/Countdown/README.md
+++ b/src/components/Countdown/README.md
@@ -1,5 +1,6 @@
 # Countdown
 
+Just an alias for Timer (to keep backward compat)
 Displays a countdown.
 
 ## Usage

--- a/src/components/Countdown/README.md
+++ b/src/components/Countdown/README.md
@@ -1,6 +1,5 @@
-# Countdown
+# Countdown (Timer alias)
 
-Just an alias for Timer (to keep backward compat)
 Displays a countdown.
 
 ## Usage

--- a/src/components/Timer/README.md
+++ b/src/components/Timer/README.md
@@ -45,6 +45,14 @@ The start of a timer, as a `Date` instance.
 
 ### `format`
 
-- Type `Enum: [ 'dhms', 'dhm', 'hms', 'hm', 'ms' ]`
+- Type `Enum: [ 'dhms', 'dhm', 'hms', 'hm', 'ms', 'm', 's' ]`
+- Default: `'dhms'`
 
 Format output in days 'd', hours 'h', minutes 'm', seconds 's'
+
+### `showEmpty`
+
+- Type `Boolean`
+- Default: `false`
+
+Display the units on the left side of the timer when they are equal to zero.

--- a/src/components/Timer/README.md
+++ b/src/components/Timer/README.md
@@ -1,0 +1,44 @@
+# Countdown
+
+Displays a countdown or stopwatch
+
+## Usage
+
+```jsx
+import { Timer } from '@aragon/ui'
+
+const DAY_IN_MS = 1000 * 60 * 60 * 24
+const endDate = new Date(Date.now() + 5 * DAY_IN_MS)
+
+const App = () => (
+  <Timer end={endDate} />
+)
+```
+
+or
+
+```jsx
+import { Timer } from '@aragon/ui'
+
+const DAY_IN_MS = 1000 * 60 * 60 * 24
+const startDate = new Date(Date.now() - 5 * DAY_IN_MS)
+
+const App = () => (
+  <Timer start={startDate} />
+)
+```
+
+
+## Properties
+
+### `end`
+
+- Type: `Date`
+
+The end of the countdown, as a `Date` instance.
+
+### `start`
+
+- Type: `Date`
+
+The start of a timer, as a `Date` instance.

--- a/src/components/Timer/README.md
+++ b/src/components/Timer/README.md
@@ -42,3 +42,9 @@ The end of the countdown, as a `Date` instance.
 - Type: `Date`
 
 The start of a timer, as a `Date` instance.
+
+### `format`
+
+- Type `Enum: [ 'dhms', 'dhm', 'hms', 'hm', 'ms' ]`
+
+Format output in days 'd', hours 'h', minutes 'm', seconds 's'

--- a/src/components/Timer/README.md
+++ b/src/components/Timer/README.md
@@ -1,4 +1,4 @@
-# Countdown
+# Timer
 
 Displays a countdown or stopwatch
 

--- a/src/components/Timer/Timer.js
+++ b/src/components/Timer/Timer.js
@@ -1,0 +1,115 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { Redraw } from '../../providers/Redraw'
+import IconTime from '../../icons/components/Time'
+import { difference, formatHtmlDatetime } from '../../utils/date'
+import { unselectable } from '../../utils/styles'
+import { theme } from '../../theme'
+
+const FRAME_EVERY = 1000 / 30 // 30 FPS is enough for a ticker
+
+const formatUnit = v => String(v).padStart(2, '0')
+
+class Timer extends React.Component {
+  static propTypes = {
+    start: PropTypes.instanceOf(Date),
+    end: PropTypes.instanceOf(Date),
+    removeDaysAndHours: PropTypes.bool,
+  }
+  render() {
+    const { end, start } = this.props
+    return (
+      <Main dateTime={formatHtmlDatetime(end || start)}>
+        <IconWrapper>
+          <IconTime />
+        </IconWrapper>
+        <Redraw interval={FRAME_EVERY}>{this.renderTime}</Redraw>
+      </Main>
+    )
+  }
+  renderTime = () => {
+    const { start, end, removeDaysAndHours } = this.props
+    const diffArgs = end ? [end, new Date()] : [new Date(), start]
+    const { days, hours, minutes, seconds, totalInSeconds } = difference(
+      ...diffArgs
+    )
+
+    if (end && totalInSeconds <= 0) {
+      return <TimeOut>Time out</TimeOut>
+    }
+    return (
+      <span>
+        {!removeDaysAndHours && (
+          <React.Fragment>
+            <Part>
+              {formatUnit(days)}
+              <Unit>D</Unit>
+            </Part>
+            <Separator />
+            <Part>
+              {formatUnit(hours)}
+              <Unit>H</Unit>
+            </Part>
+            <Separator>:</Separator>
+          </React.Fragment>
+        )}
+        <Part>
+          {formatUnit(minutes)}
+          <Unit>M</Unit>
+        </Part>
+        <Separator>:</Separator>
+        <PartSeconds>
+          {formatUnit(seconds)}
+          <UnitSeconds>S</UnitSeconds>
+        </PartSeconds>
+      </span>
+    )
+  }
+}
+
+const Main = styled.time`
+  white-space: nowrap;
+  ${unselectable()};
+`
+
+const IconWrapper = styled.span`
+  margin-right: 15px;
+`
+
+const Part = styled.span`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${theme.textPrimary};
+`
+
+const PartSeconds = styled(Part)`
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: space-between;
+  min-width: 31px;
+`
+
+const Unit = styled.span`
+  margin-left: 2px;
+  font-size: 12px;
+  color: ${theme.textSecondary};
+`
+
+const UnitSeconds = styled(Unit)`
+  position: relative;
+  left: -3px;
+`
+
+const Separator = styled.span`
+  margin: 0 4px;
+  color: ${theme.textTertiary};
+  font-weight: 400;
+`
+
+const TimeOut = styled.span`
+  font-weight: 600;
+  color: ${theme.textSecondary};
+`
+
+export default Timer

--- a/src/components/Timer/Timer.js
+++ b/src/components/Timer/Timer.js
@@ -11,12 +11,37 @@ const FRAME_EVERY = 1000 / 30 // 30 FPS is enough for a ticker
 
 const formatUnit = v => String(v).padStart(2, '0')
 
+const formats = {
+  dhms: 'dhms',
+  dhm: 'dhm',
+  hms: 'hms',
+  hm: 'hm',
+  ms: 'ms'
+}
+
+const getFormat = function (format) {
+  const timeFormat = ['d', 'h', 'm', 's']
+  const checkFormat = symbol => formats[format].includes(symbol)
+  return timeFormat.map(checkFormat)
+}
+
 class Timer extends React.Component {
   static propTypes = {
     start: PropTypes.instanceOf(Date),
     end: PropTypes.instanceOf(Date),
-    removeDaysAndHours: PropTypes.bool,
+    format: PropTypes.oneOf(Object.keys(formats))
   }
+
+  static defaultProps = {
+    format: formats.dhms
+  }
+
+  constructor(props) {
+    super(props)
+    const [showDays, showHours, showMinutes, showSeconds] = getFormat(props.format)
+    this.state = { showDays, showHours, showMinutes, showSeconds }
+  }
+
   render() {
     const { end, start } = this.props
     return (
@@ -28,8 +53,10 @@ class Timer extends React.Component {
       </Main>
     )
   }
+
   renderTime = () => {
-    const { start, end, removeDaysAndHours } = this.props
+    const { start, end } = this.props
+    const { showDays, showHours, showMinutes, showSeconds } = this.state
     const diffArgs = end ? [end, new Date()] : [new Date(), start]
     const { days, hours, minutes, seconds, totalInSeconds } = difference(
       ...diffArgs
@@ -38,31 +65,42 @@ class Timer extends React.Component {
     if (end && totalInSeconds <= 0) {
       return <TimeOut>Time out</TimeOut>
     }
+
     return (
       <span>
-        {!removeDaysAndHours && (
+        {showDays && (
           <React.Fragment>
             <Part>
               {formatUnit(days)}
               <Unit>D</Unit>
             </Part>
             <Separator />
-            <Part>
-              {formatUnit(hours)}
-              <Unit>H</Unit>
-            </Part>
-            <Separator>:</Separator>
           </React.Fragment>
         )}
-        <Part>
-          {formatUnit(minutes)}
-          <Unit>M</Unit>
-        </Part>
-        <Separator>:</Separator>
-        <PartSeconds>
-          {formatUnit(seconds)}
-          <UnitSeconds>S</UnitSeconds>
-        </PartSeconds>
+        {showHours && (
+          <Part>
+            {formatUnit(hours)}
+            <Unit>H</Unit>
+          </Part>
+        )}
+        {showHours && showMinutes && (
+          <Separator>:</Separator>
+        )}
+        {showMinutes && (
+          <Part>
+            {formatUnit(minutes)}
+            <Unit>M</Unit>
+          </Part>
+        )}
+        {showSeconds && (
+          <React.Fragment>
+            <Separator>:</Separator>
+            <PartSeconds>
+              {formatUnit(seconds)}
+              <UnitSeconds>S</UnitSeconds>
+            </PartSeconds>
+          </React.Fragment>
+        )}
       </span>
     )
   }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -33,6 +33,7 @@ export { default as TableHeader } from './Table/TableHeader'
 export { default as TableRow } from './Table/TableRow'
 export { default as Text } from './Text/Text'
 export { default as TextInput } from './Input/TextInput'
+export { default as Timer } from './Timer/Timer'
 export { ToastHub, Toast } from './ToastHub/ToastHub'
 export {
   default as TransactionProgress,


### PR DESCRIPTION
After some chat with @bpierre  on #263, I followed his advice on add a new component called Timer that support both start or end as prop (stopwatch or countdown features). At the same I have kept backwards compat with current Countdown component (that just use Timer internally).