### PR TITLE
Field: use flex to position required asterisk

### DIFF
--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -11,13 +11,14 @@ const StyledField = styled.div`
 
 const StyledAsterisk = styled.span`
   color: ${theme.accent};
-  float: right;
+  margin-left: auto;
   padding-top: 3px;
   font-size: 12px;
 `
 
 const StyledTextBlock = styled(Text.Block)`
   ${unselectable()};
+  display: flex;
 `
 
 const Field = ({ children, label, ...props }) => {


### PR DESCRIPTION
Changes the positioning to be based on flex, and uses the `margin: auto` trick to right-align rather than `justify-content: space-between` (makes it easier to add items to the left in the future, e.g. an icon).