### PR TITLE
ButtonBase: remove extra cursor css declaration

### DIFF
--- a/src/components/Button/ButtonBase.js
+++ b/src/components/Button/ButtonBase.js
@@ -30,7 +30,6 @@ const Main = styled.button.attrs({ type: 'button' })`
   background: none;
   border: 0;
   border-radius: 3px;
-  cursor: pointer;
   outline: 0;
 
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};


### PR DESCRIPTION
Super small change from #284 since `cursor` is immediately declared afterwards.