### PR TITLE
Remove styled-components from the dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "rollup-plugin-progress": "^0.4.0",
     "rollup-plugin-uglify": "^6.0.0",
     "rollup-plugin-url": "^2.0.1",
-    "styled-components": "^4.0.2",
     "svgo": "^1.0.3",
     "svgr": "^1.1.0"
   },


### PR DESCRIPTION
styled-components is a peer dependency and shouldn’t be installed here. Doing so can be problematic when using `npm link @aragon/ui` in a project, causing two versions of styled-components to be included.