### PR TITLE
ButtonIcon: require a label prop

### DIFF
--- a/src/components/Button/ButtonIcon.js
+++ b/src/components/Button/ButtonIcon.js
@@ -1,10 +1,13 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import ButtonBase from './ButtonBase'
 
 class ButtonIcon extends React.PureComponent {
   render() {
+    const { label, children, ...props } = this.props
     return (
       <ButtonBase
+        title={label}
         css={`
           display: inline-flex;
           justify-content: center;
@@ -15,10 +18,17 @@ class ButtonIcon extends React.PureComponent {
             background: rgba(220, 234, 239, 0.3);
           }
         `}
-        {...this.props}
-      />
+        {...props}
+      >
+        {children}
+      </ButtonBase>
     )
   }
+}
+
+ButtonIcon.propTypes = {
+  label: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 }
 
 export default ButtonIcon


### PR DESCRIPTION
To make sure the button is always described with text.