### PR TITLE
scripts: replace release:minor by prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "theme:build": "scripts/oco-json.js < src/theme/Aragon.oco > src/theme/aragon.json",
     "icons:build": "svgr --no-semi --replace-attr-value '#8B9396=currentColor' --no-title -d src/icons/components src/icons/svg",
     "optimize:svg": "find ./src -name *.svg -exec svgo --config '{ \"plugins\": [ { \"removeDesc\": {\"removeAny\": true} }, { \"removeTitle\": true }, { \"removeViewBox\": false } ] }' {} \\;",
-    "release:minor": "npm version minor && git push && git push --tags && npm publish",
+    "prepublishOnly": "git push && git push --tags",
     "deploy:site": "cd gallery && npm run build && echo 'ui.aragon.org' > dist/CNAME && cp public/favicon.svg dist && gh-pages -d dist",
     "prepare": "npm run build",
     "start": "cd gallery && npm start"


### PR DESCRIPTION
So we can publish using normal `npm` commands:

```
npm version [major|minor|patch]
npm publish
```
