### PR TITLE
Slider: don't propagate pressed to ActiveBar and Handle

### DIFF
--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -128,7 +128,6 @@ class Slider extends React.Component {
               <Bars>
                 <BaseBar />
                 <ActiveBar
-                  pressed={pressed}
                   style={this.getActiveBarStyles(value, pressProgress)}
                 />
               </Bars>
@@ -137,10 +136,7 @@ class Slider extends React.Component {
                 <HandlePosition
                   style={this.getHandlePositionStyles(value, pressProgress)}
                 >
-                  <Handle
-                    pressed={pressed}
-                    style={this.getHandleStyles(pressProgress)}
-                  />
+                  <Handle style={this.getHandleStyles(pressProgress)} />
                 </HandlePosition>
               </HandleClip>
             </Area>


### PR DESCRIPTION
Not sure if `pressed` is somehow used by these two inner components, but as far as I can tell they're not.

React gave an error 🤷‍♂️ 