### PR TITLE
NavigationBar: fix transition issues

### DIFF
--- a/src/components/NavigationBar/NavigationBar.js
+++ b/src/components/NavigationBar/NavigationBar.js
@@ -17,9 +17,6 @@ class NavigationBar extends React.Component {
   state = {
     cachedItems: null,
     direction: -1,
-
-    // only animate after the first rendering
-    animate: false,
   }
   static getDerivedStateFromProps(props, state) {
     const updatedState = { cachedItems: props.items }
@@ -31,12 +28,8 @@ class NavigationBar extends React.Component {
       direction: state.cachedItems.length > props.items.length ? 1 : -1,
     }
   }
-  componentDidMount() {
-    this.setState({ animate: true })
-  }
   render() {
     const { onBack, items } = this.props
-    const { animate } = this.state
     const displayedItems = items
       .map((node, index) => ({ node, index }))
       .slice(-1)
@@ -51,17 +44,17 @@ class NavigationBar extends React.Component {
             item => (items.length === 1 ? -1 : item.index)
           )}
           config={springs.smooth}
+          initial={null}
           from={{ opacity: 0, position: this.state.direction * -1 }}
           enter={{ opacity: 1, position: 0 }}
           leave={{ opacity: 0, position: this.state.direction }}
-          immediate={!animate}
           native
         >
           {item => styles => (
             <Item
               label={item.node}
               onBack={onBack}
-              displayBack={items.length > 1 && item.index > 0}
+              displayBack={item.index > 0}
               {...styles}
             />
           )}


### PR DESCRIPTION
- Ensure the arrow stays during the leave transition of an item (when moving from 2 to 1 items).
- Don’t animate when the component mounts (using the `immediate` prop of `Transition`).

Before:
<img width=400 src=https://user-images.githubusercontent.com/36158/53244815-3bf99d00-36ac-11e9-9f23-87e81c0c8b5b.gif>

After:
<img width=400 src=https://user-images.githubusercontent.com/36158/53244806-39974300-36ac-11e9-9bd5-4c35a52cf78b.gif>
