### PR TITLE
Rename Aragon UI to aragonUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aragon UI
+# aragonUI
 
 <p align=center>
   <img src="https://user-images.githubusercontent.com/36158/40653789-19f2d150-6334-11e8-9f78-8b32648698b4.png" alt="">
@@ -6,7 +6,7 @@
 
 ## What is it?
 
-Aragon UI is a React library used to build user interfaces for Aragon and its related projects. It provides the components needed to build experiences that feel integrated with Aragon ecosystem, and can be used both client or server side.
+aragonUI is a React library used to build user interfaces for Aragon and its related projects. It provides the components needed to build experiences that feel integrated with Aragon ecosystem, and can be used both client or server side.
 
 Used by:
 
@@ -43,13 +43,13 @@ const App = () => (
 )
 ```
 
-*Your project is now ready to use Aragon UI. 💫*
+*Your project is now ready to use aragonUI. 💫*
 
 Open https://ui.aragon.org/ to see the list of the available components and learn how to use them.
 
 ### Assets
 
-Aragon UI require some assets (e.g. fonts) in order to work properly. These need to be copied where they can be accessed by the library, like the `public/` directory of a project using [Create React App](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-assets-outside-of-the-module-system).
+aragonUI require some assets (e.g. fonts) in order to work properly. These need to be copied where they can be accessed by the library, like the `public/` directory of a project using [Create React App](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-assets-outside-of-the-module-system).
 
 Copy these assets using the provided `copy-aragon-ui-assets` command:
 

--- a/bin/copy-aragon-ui-assets
+++ b/bin/copy-aragon-ui-assets
@@ -58,7 +58,7 @@ async function main(argv, argspec) {
 
   return copy(source, destination).then(
     () =>
-      `\nAragon UI assets copied to ${path.relative(
+      `\naragonUI assets copied to ${path.relative(
         process.cwd(),
         destination
       )}`

--- a/gallery/public/index.html
+++ b/gallery/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Aragon UI</title>
+    <title>aragonUI</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <link rel="manifest" href="<%= htmlWebpackPlugin.options.publicUrl %>manifest.json">

--- a/gallery/public/manifest.json
+++ b/gallery/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Aragon UI",
-  "name": "Aragon UI Gallery",
+  "short_name": "aragonUI",
+  "name": "aragonUI Gallery",
   "icons": [
     {
       "src": "favicon.ico",

--- a/gallery/src/pages/PageColors.js
+++ b/gallery/src/pages/PageColors.js
@@ -11,7 +11,7 @@ const PageButton = ({ title }) => (
       <h2>Aragon Colors</h2>
       <p>
         These palettes contain the colors used by Aragon. It is not recommended
-        to refer to them in your Aragon apps, prefer using the Aragon UI Theme.
+        to refer to them in your Aragon apps, prefer using the aragonUI Theme.
       </p>
       {Object.entries(colors).map(([name, colors]) => (
         <ColorGroup

--- a/gallery/src/pages/PageHome.js
+++ b/gallery/src/pages/PageHome.js
@@ -18,10 +18,10 @@ const illustrations = [
 const positions = [0, 0.5, 0.85, 1]
 
 const PageHome = () => (
-  <Page title="Aragon UI">
+  <Page title="aragonUI">
     <div>
       <p>
-        Aragon UI allows you to develop apps that look and feel like Aragon
+        aragonUI allows you to develop apps that look and feel like Aragon
         apps.
       </p>
       <Illustrations>

--- a/gallery/src/pages/PageTheme.js
+++ b/gallery/src/pages/PageTheme.js
@@ -7,7 +7,7 @@ import readme from 'ui-src/theme/README.md'
 
 const PageButton = ({ title }) => (
   <Page title={title} readme={readme}>
-    <ColorGroup name="Aragon UI Theme" colors={theme} />
+    <ColorGroup name="aragonUI Theme" colors={theme} />
   </Page>
 )
 

--- a/gallery/src/routes.js
+++ b/gallery/src/routes.js
@@ -123,6 +123,6 @@ export const PAGE_GROUPS = [
 ].map(group => ({ ...group, pages: group.pages.map(preparePage) }))
 
 export const PAGES = [
-  preparePage([PageHome, 'Aragon UI', '/']),
+  preparePage([PageHome, 'aragonUI', '/']),
   ...PAGE_GROUPS.reduce((pages, group) => pages.concat(group.pages), []),
 ]

--- a/src/components/Main/README.md
+++ b/src/components/Main/README.md
@@ -28,4 +28,4 @@ Set this to `true` if you wish to support for WOFF 1.0 browsers (like Internet E
 - Type: `String`
 - Default: `./aragon-ui/`
 
-Set this to configure the URL of the directory containing your Aragon UI assets.
+Set this to configure the URL of the directory containing your aragonUI assets.

--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -1,6 +1,6 @@
 # Theme
 
-The Aragon UI Theme can be used to style your applications.
+The aragonUI theme can be used to style your applications.
 
 ## Usage
 


### PR DESCRIPTION
See [this forum post](https://forum.aragon.org/t/on-aragon-naming/203) for context.

Note: I kept instances of `aragon-ui` in the code, and the color palettes are still named `Aragon UI`. For the color palettes, I don’t think it’s worth breaking the compatibility now, since we are going to do it with the move to Lorikeet anyway.