### PR TITLE
IdentityBadge: add rules for text overflow

### DIFF
--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -105,7 +105,6 @@ const Identicon = styled.div`
 
 const Label = styled(Text)`
   padding: 0 8px;
-  display: inline-block;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -59,6 +59,7 @@ class IdentityBadge extends React.PureComponent {
           onClick={address && this.handleOpen}
           css={`
             display: inline-flex;
+            overflow: hidden;
             color: ${theme.textPrimary};
           `}
         >
@@ -104,7 +105,10 @@ const Identicon = styled.div`
 
 const Label = styled(Text)`
   padding: 0 8px;
+  display: inline-block;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 `
 
 export default IdentityBadge


### PR DESCRIPTION
Updates rules for text overflow when IdentityBadge has limited space.

![image](https://user-images.githubusercontent.com/3072458/54681661-3a858e00-4b0d-11e9-8c4a-9f5d44aafa70.png)
