### PR TITLE
Popover: fix the click outside detection

### DIFF
--- a/devbox/apps/Popover.js
+++ b/devbox/apps/Popover.js
@@ -1,61 +1,46 @@
-import React from 'react'
+import React, { useRef, useState, useCallback } from 'react'
 import styled from 'styled-components'
 import { Popover, Root, Button } from '@aragon/ui'
 
-class App extends React.Component {
-  _opener = React.createRef()
-  state = {
-    show: false,
-  }
-  handleClose = () => {
-    this.setState({ show: false })
-  }
-  handleOpen = () => {
-    this.setState({ show: true })
-  }
-  render() {
-    const { title } = this.props
-    const { show } = this.state
-    return (
-      <Main>
-        <div>
-          <Button
-            ref={this._opener}
-            onClick={this.handleOpen}
-            size="small"
-            mode="strong"
-          >
-            Open
-          </Button>
-          <Popover
-            opener={this._opener.current}
-            visible={show}
-            onClose={this.handleClose}
-          >
-            <Box>
-              <span>hello </span>
-              <Button mode="strong" size="mini">
-                focus me
-              </Button>
-            </Box>
-          </Popover>
-        </div>
-      </Main>
-    )
-  }
+function App({ title }) {
+  const [show, setShow] = useState(false)
+  const [opener, setOpener] = useState(null)
+
+  const handleOpenerRef = useCallback(node => {
+    setOpener(node)
+  }, [])
+
+  return (
+    <div
+      css={`
+        display: grid;
+        width: 800px;
+        margin: 0 auto;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      `}
+    >
+      <div>
+        <Button
+          ref={handleOpenerRef}
+          onClick={() => setShow(true)}
+          size="small"
+          mode="strong"
+        >
+          Open
+        </Button>
+        <Popover opener={opener} visible={show} onClose={() => setShow(false)}>
+          <div css="padding: 50px">
+            <span>hello </span>
+            <Button mode="secondary" size="mini">
+              focus me
+            </Button>
+          </div>
+        </Popover>
+      </div>
+    </div>
+  )
 }
-
-const Main = styled.div`
-  display: grid;
-  width: 800px;
-  margin: 0 auto;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-`
-
-const Box = styled.div`
-  padding: 50px;
-`
 
 export default App


### PR DESCRIPTION
Fix the super annoying bug where outside clicks were not detected below the popover.

Also move from `Root` to `RootPortal`.