### PR TITLE
IdentityBadge: fix props warning message

### DIFF
--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -62,7 +62,7 @@ class IdentityBadge extends React.PureComponent {
           ref={this._element}
           title={address}
           disabled={badgeOnly}
-          onClick={address && !badgeOnly && this.handleOpen}
+          onClick={address && !badgeOnly ? this.handleOpen : undefined}
           css={`
             display: inline-flex;
             overflow: hidden;


### PR DESCRIPTION
React was complaining that it was receiving a boolean prop for what should've been a function.