### PR TITLE
Added render prop to SidePanel

### DIFF
--- a/src/components/SidePanel/SidePanel.js
+++ b/src/components/SidePanel/SidePanel.js
@@ -29,7 +29,7 @@ class SidePanel extends React.PureComponent {
     this.props.onTransitionEnd(this.props.opened)
   }
   renderIn = ({ progress }) => {
-    const { children, title, opened, blocking } = this.props
+    const { children, render, title, opened, blocking } = this.props
 
     return (
       <Main opened={opened}>
@@ -60,7 +60,7 @@ class SidePanel extends React.PureComponent {
             )}
           </PanelHeader>
           <PanelScrollView>
-            <PanelContent>{children}</PanelContent>
+            <PanelContent>{render ? render(opened) : children}</PanelContent>
           </PanelScrollView>
         </Panel>
       </Main>
@@ -89,6 +89,7 @@ SidePanel.propTypes = {
   blocking: PropTypes.bool,
   onClose: PropTypes.func,
   onTransitionEnd: PropTypes.func,
+  render: PropTypes.func,
 }
 
 SidePanel.defaultProps = {


### PR DESCRIPTION
Resolves #347 

Creates a render prop and renders it over the children if present, else renders the children.

I was uncertain what the behavior should be if both a render prop and children are present, and chose to prioritize the render prop. Should the children be rendered as well?