### PR TITLE
BackButton tweaks

### DIFF
--- a/src/components/BackButton/BackButton.js
+++ b/src/components/BackButton/BackButton.js
@@ -12,12 +12,16 @@ function BackButton({ label, ...props }) {
   return (
     <ButtonBase
       focusRingRadius={RADIUS}
+      focusRingSpacing={1}
       css={`
-        border-radius: 0;
+        display: inline-flex;
+        align-items: center;
+        border-radius: ${RADIUS}px 0 0 ${RADIUS}px;
         height: 100%;
         margin-left: ${insideBarPrimary ? -Bar.PADDING : 0}px;
         padding: 0 ${3 * GU}px;
         border-right: 1px solid ${theme.border};
+        color: ${theme.surfaceContent};
         background: ${theme.surfaceInteractive};
         &:active {
           background: ${theme.surfaceHighlight};
@@ -37,7 +41,6 @@ function BackButton({ label, ...props }) {
       <span
         css={`
           padding-left: ${1 * GU}px;
-          color: ${theme.surfaceContent};
           font-size: 16px;
           font-weight: 600;
         `}

--- a/src/components/BackButton/BackButton.js
+++ b/src/components/BackButton/BackButton.js
@@ -4,6 +4,7 @@ import { RADIUS, GU } from '../../style'
 import { useTheme } from '../../theme'
 import { ButtonBase } from '../Button/ButtonBase'
 import { Bar, useInsideBar } from '../Bar/Bar'
+import { IconArrowLeft } from '../../icons'
 
 function BackButton({ label, ...props }) {
   const theme = useTheme()
@@ -27,10 +28,11 @@ function BackButton({ label, ...props }) {
       <span
         css={`
           position: relative;
-          top: 1px;
+          top: 2px;
+          color: ${theme.accent};
         `}
       >
-        <Arrow color={theme.accent} />
+        <IconArrowLeft />
       </span>
       <span
         css={`
@@ -52,23 +54,6 @@ BackButton.propTypes = {
 
 BackButton.defaultProps = {
   label: 'Back',
-}
-
-function Arrow({ color, ...props }) {
-  return (
-    <svg width={15} height={14} fill="none" {...props}>
-      <path
-        d="M7.47418 11.89L7.47416 11.8901C7.74229 12.1687 7.74411 12.6185 7.47288 12.8902C7.19413 13.17 6.75335 13.1699 6.47463 12.8901L1.10282 7.49629C0.832467 7.22484 0.832322 6.77477 1.10282 6.50371L7.47418 11.89ZM7.47418 11.89L7.4729 11.8888L3.2996 7.70621H13.5C13.8897 7.70621 14.2083 7.38572 14.2083 6.99539C14.2083 6.60321 13.8879 6.29325 13.5 6.29325H3.29928L7.47288 2.10258C7.74346 1.83153 7.74334 1.3814 7.47296 1.10991C7.19422 0.830029 6.75338 0.830029 6.47463 1.10991L1.1029 6.50363L7.47418 11.89Z"
-        fill={color}
-        stroke={color}
-        strokeWidth={0.2}
-      />
-    </svg>
-  )
-}
-
-Arrow.propTypes = {
-  color: PropTypes.object.isRequired,
 }
 
 export { BackButton }


### PR DESCRIPTION
- Remove custom icon.
- Align the focus ring on the border.
- Round corners so that Bar doesn’t need `overflow: hidden`.