### PR TITLE
Button: disabled state + display prop

### DIFF
--- a/devbox/apps/Button.js
+++ b/devbox/apps/Button.js
@@ -8,6 +8,7 @@ import {
   Button,
   Text,
   theme,
+  GU,
 } from '@aragon/ui'
 
 const MODES = ['normal', 'strong', 'positive', 'negative']
@@ -38,12 +39,16 @@ function App() {
         bottom: 0;
       `}
     >
-      <Box css="padding: 24px">
+      <Box
+        css={`
+          padding: ${3 * GU}px;
+        `}
+      >
         <div
           css={`
             display: grid;
             grid-template-columns: repeat(4, auto);
-            grid-gap: 24px;
+            grid-gap: ${3 * GU}px;
           `}
         >
           {SIZES.map(size =>

--- a/devbox/apps/Button.js
+++ b/devbox/apps/Button.js
@@ -53,9 +53,9 @@ function App() {
                   key={size + mode + i}
                   mode={mode}
                   size={size}
-                  label={mode}
+                  label={mode[0].toUpperCase() + mode.slice(1)}
                   icon={getIcon(mode)}
-                  display={i === 1 ? 'icon' : 'label'}
+                  display={i === 1 ? 'icon' : i === 0 ? 'all' : 'label'}
                   disabled={i === 3}
                 />
               ))

--- a/devbox/apps/Button.js
+++ b/devbox/apps/Button.js
@@ -1,6 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
-import { IconCheck, IconCross, IconAdd, Button, Text, theme } from '@aragon/ui'
+import {
+  Box,
+  IconCheck,
+  IconCross,
+  IconAdd,
+  Button,
+  Text,
+  theme,
+} from '@aragon/ui'
 
 const MODES = ['normal', 'strong', 'positive', 'negative']
 const SIZES = ['normal', 'small']
@@ -28,60 +36,33 @@ function App() {
         left: 0;
         right: 0;
         bottom: 0;
-        overflow-y: scroll;
-        overflow-x: hidden;
-        background: hsl(200, 30%, 85%);
       `}
     >
-      <div
-        css={`
-          min-height: 0;
-          h1 {
-            margin: 40px 0;
-            text-align: center;
-          }
-          h2 {
-            margin: 20px 0;
-            text-align: center;
-          }
-          .emphasis {
-            padding: 20px 0 80px;
-          }
-          .row {
-            display: flex;
-            justify-content: center;
-            margin-bottom: 20px;
-            > span {
-              margin-left: 10px;
-            }
-          }
-        `}
-      >
-        {null && (
-          <h1>
-            <Text size="xxlarge">Button variations</Text>
-          </h1>
-        )}
-        <div css="padding: 40px 0">
+      <Box css="padding: 24px">
+        <div
+          css={`
+            display: grid;
+            grid-template-columns: repeat(4, auto);
+            grid-gap: 24px;
+          `}
+        >
           {SIZES.map(size =>
-            MODES.map(mode => (
-              <div key={size + mode} css="display: flex">
-                {[...Array(3)].map((_, i) => (
-                  <div key={size + mode + i} css="margin: 0 20px 20px 0">
-                    <Button
-                      mode={mode}
-                      size={size}
-                      label={mode}
-                      icon={i > 0 ? getIcon(mode) : null}
-                      iconOnly={i === 1}
-                    />
-                  </div>
-                ))}
-              </div>
-            ))
+            MODES.map(mode =>
+              [...Array(4)].map((_, i) => (
+                <Button
+                  key={size + mode + i}
+                  mode={mode}
+                  size={size}
+                  label={mode}
+                  icon={getIcon(mode)}
+                  display={i === 1 ? 'icon' : 'label'}
+                  disabled={i === 3}
+                />
+              ))
+            )
           )}
         </div>
-      </div>
+      </Box>
     </div>
   )
 }

--- a/devbox/apps/Wrappers.js
+++ b/devbox/apps/Wrappers.js
@@ -12,6 +12,7 @@ import {
   Tabs,
   Theme,
   useLayout,
+  IconPlus,
 } from '@aragon/ui'
 import { ToggleThemeButton } from '../components/toggle-theme'
 
@@ -19,7 +20,7 @@ function Header1() {
   return (
     <Header
       primary="Voting"
-      secondary={<Button mode="strong" label="New vote" />}
+      secondary={<Button mode="strong" label="New vote" icon={<IconPlus />} />}
     />
   )
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -7,7 +7,15 @@ import { warn, warnOnce, useInside } from '../../utils'
 import { useLayout } from '../Layout/Layout'
 import { ButtonBase } from './ButtonBase'
 
-function buttonStyles(mode, theme) {
+function buttonStyles(theme, { mode, disabled }) {
+  if (disabled) {
+    return {
+      background: theme.disabled,
+      color: theme.disabledContent,
+      iconColor: theme.disabledContent,
+      border: '0',
+    }
+  }
   if (mode === 'strong') {
     return {
       background: `
@@ -51,6 +59,7 @@ function buttonStyles(mode, theme) {
 
 function Button({
   children,
+  disabled,
   display,
   icon,
   iconOnly,
@@ -111,8 +120,8 @@ function Button({
 
   // Styles
   const { background, color, iconColor, border } = useMemo(
-    () => buttonStyles(mode, theme),
-    [mode, theme]
+    () => buttonStyles(theme, { mode, disabled }),
+    [mode, theme, disabled]
   )
 
   const width = wide ? '100%' : 'auto'
@@ -129,6 +138,7 @@ function Button({
       ref={innerRef}
       focusRingSpacing={border === '0' ? 3 : 4}
       focusRingRadius={RADIUS}
+      disabled={disabled}
       css={`
         display: ${wide ? 'flex' : 'inline-flex'};
         align-items: center;
@@ -142,13 +152,13 @@ function Button({
         padding: ${displayIconOnly ? 0 : padding};
         min-width: ${displayIconOnly ? 0 : 16 * GU}px;
         border: ${border};
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        box-shadow: ${disabled ? 'none' : '0 1px 3px rgba(0, 0, 0, 0.1)'};
         transition-property: transform, box-shadow;
         transition-duration: 50ms;
         transition-timing-function: ease-in-out;
         &:active {
-          transform: translateY(1px);
-          box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.125);
+          transform: ${disabled ? 'none' : 'translateY(1px)'};
+          box-shadow: ${disabled ? 'none' : '0px 1px 3px rgba(0, 0, 0, 0.125)'};
         }
       `}
       {...props}
@@ -183,6 +193,7 @@ function Button({
 
 Button.propTypes = {
   children: PropTypes.node,
+  disabled: PropTypes.bool,
   display: PropTypes.oneOf(['auto', 'all', 'icon', 'label']),
   icon: PropTypes.node,
   innerRef: PropTypes.any,
@@ -213,6 +224,7 @@ Button.propTypes = {
 }
 
 Button.defaultProps = {
+  disabled: false,
   display: 'auto',
   mode: 'normal',
   size: 'normal',

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -181,7 +181,7 @@ function Button({
           {displayIcon && displayLabel && (
             <span
               css={`
-                width: ${0.5 * GU}px;
+                width: ${1 * GU}px;
               `}
             />
           )}

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -126,7 +126,8 @@ function Button({
 
   const width = wide ? '100%' : 'auto'
   const height = size === 'small' ? `${4 * GU}px` : `${5 * GU}px`
-  const padding = size === 'small' ? `0 ${2 * GU}px` : `0 ${3 * GU}px`
+  const padding = size === 'small' ? `0 ${1.5 * GU}px` : `0 ${3 * GU}px`
+  const minWidth = size === 'small' ? `${14 * GU}px` : `${16 * GU}px`
 
   // Use the label as a title when only the icon is displayed
   if (displayIconOnly) {
@@ -136,7 +137,7 @@ function Button({
   return (
     <ButtonBase
       ref={innerRef}
-      focusRingSpacing={border === '0' ? 3 : 4}
+      focusRingSpacing={border === '0' ? 0 : 1}
       focusRingRadius={RADIUS}
       disabled={disabled}
       css={`
@@ -150,7 +151,7 @@ function Button({
         width: ${displayIconOnly ? height : width};
         height: ${height};
         padding: ${displayIconOnly ? 0 : padding};
-        min-width: ${displayIconOnly ? 0 : 16 * GU}px;
+        min-width: ${displayIconOnly ? 0 : minWidth}px;
         border: ${border};
         box-shadow: ${disabled ? 'none' : '0 1px 3px rgba(0, 0, 0, 0.1)'};
         transition-property: transform, box-shadow;
@@ -180,7 +181,7 @@ function Button({
           {displayIcon && displayLabel && (
             <span
               css={`
-                width: ${1 * GU}px;
+                width: ${0.5 * GU}px;
               `}
             />
           )}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { GU, textStyle } from '../../style'
 import { useTheme } from '../../theme'
 import { useLayout } from '../Layout/Layout'
+import { Inside } from '../../utils'
 
 function Header({ primary, secondary, children }) {
   const theme = useTheme()
@@ -10,44 +11,50 @@ function Header({ primary, secondary, children }) {
   const fullWidth = layoutName === 'small'
 
   return (
-    <div
-      css={`
-        padding: ${fullWidth ? 0 : 3 * GU}px 0;
-        background: ${fullWidth ? theme.surface : 'none'};
-        margin-bottom: ${fullWidth ? 2 * GU : 0}px;
-        box-shadow: ${fullWidth ? '0px 2px 3px rgba(0, 0, 0, 0.05)' : 'none'};
-      `}
-    >
+    <Inside name="Header">
       <div
         css={`
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          height: ${fullWidth ? 8 * GU : 5 * GU}px;
-          padding: 0 ${fullWidth && !children ? 2 * GU : 0}px;
+          padding: ${fullWidth ? 0 : 3 * GU}px 0;
+          background: ${fullWidth ? theme.surface : 'none'};
+          margin-bottom: ${fullWidth ? 2 * GU : 0}px;
+          box-shadow: ${fullWidth ? '0px 2px 3px rgba(0, 0, 0, 0.05)' : 'none'};
         `}
       >
-        {children || (
-          <>
-            <div>
-              {typeof primary === 'string' ? (
-                <h1
-                  css={`
-                    color: ${theme.content};
-                    ${textStyle(fullWidth ? 'title3' : 'title2')};
-                  `}
-                >
-                  {primary}
-                </h1>
-              ) : (
-                primary
-              )}
-            </div>
-            <div>{secondary}</div>
-          </>
-        )}
+        <div
+          css={`
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: ${fullWidth ? 8 * GU : 5 * GU}px;
+            padding: 0 ${fullWidth && !children ? 2 * GU : 0}px;
+          `}
+        >
+          {children || (
+            <>
+              <div>
+                <Inside name="Header:primary">
+                  {typeof primary === 'string' ? (
+                    <h1
+                      css={`
+                        color: ${theme.content};
+                        ${textStyle(fullWidth ? 'title3' : 'title2')};
+                      `}
+                    >
+                      {primary}
+                    </h1>
+                  ) : (
+                    primary
+                  )}
+                </Inside>
+              </div>
+              <div>
+                <Inside name="Header:secondary">{secondary}</Inside>
+              </div>
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </Inside>
   )
 }
 

--- a/src/theme/theme-dark.js
+++ b/src/theme/theme-dark.js
@@ -65,6 +65,8 @@ export default {
   focus: colors.Blue,
   selected: colors.AragonBlue,
   selectedContent: colors.White,
+  disabled: colors.GreyLight,
+  disabledContent: colors.White,
 
   control: '#F3F9FB',
   controlBorder: '#DEEDF1',

--- a/src/theme/theme-light.js
+++ b/src/theme/theme-light.js
@@ -65,6 +65,8 @@ export default {
   focus: colors.Blue,
   selected: colors.AragonBlue,
   selectedContent: colors.White,
+  disabled: colors.GreyLight,
+  disabledContent: colors.White,
 
   control: '#F3F9FB',
   controlBorder: '#DEEDF1',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36158/62335547-73c30700-b4cc-11e9-845c-44f4005919ca.png)

The `display` prop can be used to force the button to behave in certain ways. It replaces `iconOnly`, which is now deprecated.

`display` values:

- `all`: both the icon and the label are displayed.
- `icon`: only the icon gets displayed.
- `label`: only the label gets displayed.
- `auto` (default): like `all` except in some cases (one for now, see below).

If the Button is inside the secondary slot of Header and its display is set to auto, it will alternate between displaying only the label and only the icon, depending on the current layout.