### PR TITLE
Info: description mode + tweaks

### DIFF
--- a/devbox/apps/Info.js
+++ b/devbox/apps/Info.js
@@ -3,19 +3,14 @@ import { Split, Box, Info } from '@aragon/ui'
 
 const MODES = ['info', 'warning', 'error', 'description']
 
-function InfoDemo({ content, title = '' }) {
+function InfoDemo({ content, title }) {
   return (
-    <Box
-      css={`
-        margin-top: 24px;
-        flex-grow: 2;
-      `}
-    >
+    <Box css="margin-top: 48px">
       {MODES.map((mode, i) => (
         <Info
           key={i}
           mode={mode}
-          title={title}
+          title={title ? mode : ''}
           css={`
             & + & {
               margin-top: 16px;
@@ -39,13 +34,15 @@ export default () => (
           sed diam voluptua.
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
           nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
-          sed diam voluptua.
+          sed diam voluptua, consetetur sadipscing elitr et dolore magna
+          aliquyam erat aliquyam consetetur sadipscing tempor magna
+          aliquyam erat invidunt.
         "
       />
     }
     secondary={
       <InfoDemo
-        title="Lorem ipsum dolor sit amet"
+        title
         content="
           Lorem ipsum dolor sit amet, consetetur sadipscing elitr, nonumy
           eirmod tempor.

--- a/devbox/apps/Info.js
+++ b/devbox/apps/Info.js
@@ -1,38 +1,56 @@
 import React from 'react'
-import { Box, Info } from '@aragon/ui'
+import { Split, Box, Info } from '@aragon/ui'
 
-export default () => (
-  <div
-    css={`
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    `}
-  >
+const MODES = ['info', 'warning', 'error', 'description']
+
+function InfoDemo({ content, title = '' }) {
+  return (
     <Box
       css={`
         margin-top: 24px;
         flex-grow: 2;
       `}
     >
-      {[{}, { title: 'My title' }, { mode: 'warning' }, { mode: 'error' }].map(
-        (props, i) => (
-          <Info
-            key={i}
-            {...props}
-            css={`
-              & + & {
-                margin-top: 16px;
-              }
-            `}
-          >
-            Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
-            nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
-            erat, sed diam voluptua.
-          </Info>
-        )
-      )}
+      {MODES.map((mode, i) => (
+        <Info
+          key={i}
+          mode={mode}
+          title={title}
+          css={`
+            & + & {
+              margin-top: 16px;
+            }
+          `}
+        >
+          {content}
+        </Info>
+      ))}
     </Box>
-  </div>
+  )
+}
+
+export default () => (
+  <Split
+    primary={
+      <InfoDemo
+        content="
+          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+          nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+          sed diam voluptua.
+          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+          nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+          sed diam voluptua.
+        "
+      />
+    }
+    secondary={
+      <InfoDemo
+        title="Lorem ipsum dolor sit amet"
+        content="
+          Lorem ipsum dolor sit amet, consetetur sadipscing elitr, nonumy
+          eirmod tempor.
+        "
+      />
+    }
+  />
 )

--- a/src/components/Info/Info.js
+++ b/src/components/Info/Info.js
@@ -9,6 +9,7 @@ function getModeStyles(theme, mode) {
       background: theme.warningSurface.alpha(0.24),
       borderColor: theme.warning,
       color: theme.warningSurfaceContent,
+      titleColor: theme.warningSurfaceContent,
     }
   }
   if (mode === 'error') {
@@ -16,12 +17,22 @@ function getModeStyles(theme, mode) {
       background: theme.negativeSurface.alpha(0.24),
       borderColor: theme.negative,
       color: theme.negativeSurfaceContent,
+      titleColor: theme.negativeSurfaceContent,
+    }
+  }
+  if (mode === 'description') {
+    return {
+      background: theme.infoSurface.alpha(0.08),
+      borderColor: theme.info,
+      color: theme.surfaceContent,
+      titleColor: theme.surfaceContentSecondary,
     }
   }
   return {
     background: theme.infoSurface.alpha(0.08),
     borderColor: theme.info,
     color: theme.infoSurfaceContent,
+    titleColor: theme.infoSurfaceContent,
   }
 }
 
@@ -40,11 +51,6 @@ function Info({
   // Get styles from the current mode
   const modeStyles = useMemo(() => {
     const styles = getModeStyles(theme, mode)
-
-    // Use surfaceContent if a title is used
-    if (title) {
-      styles.color = theme.surfaceContent
-    }
 
     return styles
   }, [mode, theme, title])
@@ -67,7 +73,7 @@ function Info({
           css={`
             display: flex;
             align-items: center;
-            color: ${titleColor || theme.surfaceContentSecondary};
+            color: ${titleColor || modeStyles.titleColor};
             ${textStyle('label2')};
           `}
         >
@@ -82,7 +88,7 @@ function Info({
 Info.propTypes = {
   children: PropTypes.node,
   title: PropTypes.node,
-  mode: PropTypes.oneOf(['info', 'warning', 'error']),
+  mode: PropTypes.oneOf(['info', 'description', 'warning', 'error']),
   color: PropTypes.string,
   titleColor: PropTypes.string,
   background: PropTypes.string,

--- a/src/components/Info/Info.js
+++ b/src/components/Info/Info.js
@@ -75,6 +75,7 @@ function Info({
             align-items: center;
             color: ${titleColor || modeStyles.titleColor};
             ${textStyle('label2')};
+            margin-bottom: ${1 * GU}px;
           `}
         >
           {title}

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -1,9 +1,13 @@
 import React from 'react'
 import { Info } from './Info'
 
+function Warning(props) {
+  return <Info mode="warning" {...props} />
+}
+
 // Backward compatibility
 Info.Action = Info
-Info.Permissions = Info
-Info.Alert = props => <Info mode="warning" {...props} />
+Info.Permissions = Warning
+Info.Alert = Warning
 
 export { Info }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36158/62335958-60b13680-b4ce-11e9-8d89-804136745f4d.png)


- “Description” mode (with the grey text, used for radspec).
- Fix title spacing.
- Fix `Info.Permissions` (`warning` rather than `info`).
