### PR TITLE
DropDown: add placeholder, renderLabel and wide props

### DIFF
--- a/devbox/apps/DropDown.js
+++ b/devbox/apps/DropDown.js
@@ -16,7 +16,7 @@ class App extends React.Component {
         <Container>
           <DropDown
             items={items}
-            label="Which fruit?"
+            placeholder="Which fruit?"
             header="Fruits"
             selected={active}
             onChange={this.handleChange}

--- a/devbox/apps/DropDown.js
+++ b/devbox/apps/DropDown.js
@@ -20,7 +20,7 @@ class App extends React.Component {
             header="Fruits"
             selected={active}
             onChange={this.handleChange}
-            width="400px"
+            wide
           />
         </Container>
       </Main>

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -8,9 +8,9 @@ import { GU, RADIUS, textStyle } from '../../style'
 import { useTheme } from '../../theme'
 import { warnOnce, unselectable } from '../../utils'
 
-function useDropDown({ items, selected, onChange, label }) {
+function useDropDown({ items, selected, onChange, label, placeholder }) {
   const buttonRef = useRef()
-  const [selectedLabel, setSelectedLabel] = useState(label)
+  const [selectedLabel, setSelectedLabel] = useState(placeholder || label)
   const [opened, setOpened] = useState(false)
   const handleClose = useCallback(() => {
     // if the popover is opened and the user clicks on the button
@@ -60,6 +60,8 @@ const DropDown = React.memo(function DropDown({
   header,
   items,
   label,
+  placeholder,
+  renderLabel,
   onChange,
   selected,
   width,
@@ -94,6 +96,7 @@ const DropDown = React.memo(function DropDown({
     selected,
     items,
     label,
+    placeholder,
     onChange,
   })
   const closedWithChanges = !opened && selectedIndex !== -1
@@ -119,7 +122,7 @@ const DropDown = React.memo(function DropDown({
             ${textStyle('body2')};
           `}
         >
-          {selectedLabel}
+          {renderLabel || selectedLabel}
         </span>
         <IconDown
           size="tiny"
@@ -185,17 +188,19 @@ const DropDown = React.memo(function DropDown({
 DropDown.propTypes = {
   header: PropTypes.node,
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
-  label: PropTypes.string,
+  placeholder: PropTypes.string,
+  renderLabel: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   selected: PropTypes.number,
   width: PropTypes.string,
 
   // deprecated
   active: PropTypes.number,
+  label: PropTypes.string,
 }
 
 DropDown.defaultProps = {
-  label: 'Select an item',
+  placeholder: 'Select an item',
 }
 
 const Item = React.memo(function Item({

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -56,15 +56,17 @@ function useDropDown({ items, selected, onChange, label, placeholder }) {
 }
 
 const DropDown = React.memo(function DropDown({
-  active,
   header,
   items,
-  label,
   placeholder,
   renderLabel,
   onChange,
   selected,
   width,
+
+  // deprecated
+  active,
+  label,
 }) {
   if (active !== undefined) {
     warnOnce(
@@ -195,9 +197,9 @@ const DropDown = React.memo(function DropDown({
 DropDown.propTypes = {
   header: PropTypes.node,
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
+  onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.node,
   renderLabel: PropTypes.func,
-  onChange: PropTypes.func.isRequired,
   selected: PropTypes.number,
   width: PropTypes.string,
 

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -129,7 +129,7 @@ const DropDown = React.memo(function DropDown({
             ${textStyle('body2')};
           `}
         >
-          {Label ? <Label selectedIndex={selectedIndex} /> : selectedLabel}
+          <Label selectedIndex={selectedIndex} selectedLabel={selectedLabel} />
         </span>
         <IconDown
           size="tiny"
@@ -208,6 +208,7 @@ DropDown.propTypes = {
 
 DropDown.defaultProps = {
   placeholder: 'Select an item',
+  renderLabel: ({ selectedLabel }) => selectedLabel,
 }
 
 const Item = React.memo(function Item({

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -72,6 +72,12 @@ const DropDown = React.memo(function DropDown({
       'The “active” prop is deprecated. Please use “selected” to pass the selected index instead.'
     )
   }
+  if (label !== undefined) {
+    warnOnce(
+      'DropDown:label',
+      'DropDown: the “label” prop is deprecated, please use “placeholder” instead.'
+    )
+  }
 
   const selectedIndex = useMemo(() => {
     if (active !== undefined) {
@@ -100,6 +106,7 @@ const DropDown = React.memo(function DropDown({
     onChange,
   })
   const closedWithChanges = !opened && selectedIndex !== -1
+  const Label = renderLabel
 
   return (
     <React.Fragment>
@@ -122,7 +129,7 @@ const DropDown = React.memo(function DropDown({
             ${textStyle('body2')};
           `}
         >
-          {renderLabel || selectedLabel}
+          {Label ? <Label selectedIndex={selectedIndex} /> : selectedLabel}
         </span>
         <IconDown
           size="tiny"
@@ -188,8 +195,8 @@ const DropDown = React.memo(function DropDown({
 DropDown.propTypes = {
   header: PropTypes.node,
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
-  placeholder: PropTypes.string,
-  renderLabel: PropTypes.string,
+  placeholder: PropTypes.node,
+  renderLabel: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   selected: PropTypes.number,
   width: PropTypes.string,

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -7,6 +7,7 @@ import { IconDown } from '../../icons'
 import { GU, RADIUS, textStyle } from '../../style'
 import { useTheme } from '../../theme'
 import { warnOnce, unselectable } from '../../utils'
+import { useViewport } from '../../providers/Viewport/Viewport'
 
 function useDropDown({
   buttonRef,
@@ -82,13 +83,6 @@ function useButtonRef(cb) {
   }
 }
 
-function useWindowResize(onResize) {
-  useEffect(() => {
-    window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
-  }, [])
-}
-
 const DropDown = React.memo(function DropDown({
   header,
   items,
@@ -136,11 +130,12 @@ const DropDown = React.memo(function DropDown({
   })
 
   // And every time the viewport resizes
-  useWindowResize(() => {
+  const { width: vw } = useViewport()
+  useEffect(() => {
     if (buttonRef.current) {
       setButtonWidth(buttonRef.current.clientWidth)
     }
-  })
+  }, [vw, buttonRef])
 
   const {
     handleChange,

--- a/src/components/DropDown/README.md
+++ b/src/components/DropDown/README.md
@@ -5,65 +5,93 @@ A DropDown component.
 ## Usage
 
 ```jsx
-import { Component } from 'react'
 import { DropDown } from '@aragon/ui'
 
-const items = [
-  'Wandering Thunder',
-  'Black Wildflower',
-  'Ancient Paper',
-]
-
-class App extends Component {
-  state = {
-    activeItem: 0,
-  }
-  handleChange(index) {
-    this.setState({ activeItem: index })
-  }
-  render() {
-    return (
-      <DropDown
-        items={items}
-        active={this.state.activeItem}
-        onChange={this.handleChange}
-      />
-    )
-  }
+function App() {
+  const [selected, setSelected] = useState(0)
+  return (
+    <DropDown
+      items={['Wandering Thunder', 'Black Wildflower', 'Ancient Paper']}
+      selected={selected}
+      onChange={setSelected}
+    />
+  )
 }
 ```
 
 ## Props
 
+### `header`
+
+| Type         | Default value |
+| ------------ | ------------- |
+| `React node` | None          |
+
+A header that will appear at the beginning of the items menu.
+
 ### `items`
 
-- Type: `Array`
-- Default: `[]`
+| Type    | Default value   |
+| ------- | --------------- |
+| `Array` | None (required) |
 
 Use this property to define the items of the DropDown menu.
 
-### `active`
+### placeholder
 
-- Type: `Number`
-- Default: `0`
+| Type         | Default value      |
+| ------------ | ------------------ |
+| `React node` | `"Select an item"` |
 
-Set this property to the index of the active item.
+The node displayed in the button when there is no selection.
 
-### `onChange`
+### renderLabel
 
-- Type: `Function`: `(index: Number, items: Array) -> *`
-- Default: `undefined`
+| Type              | Default value                          |
+| ----------------- | -------------------------------------- |
+| `React component` | `({ selectedLabel }) => selectedLabel` |
+
+A function (or React component), used to display the button label.
+
+#### Props
+
+- `selectedLabel` (`String`): label of the selected item.
+- `selectedIndex` (`Number`): index of the selected item.
+
+### onChange(index, items)
+
+| Type       | Default value   |
+| ---------- | --------------- |
+| `Function` | None (required) |
 
 This callback is called whenever the user selects a new item.
 
-#### Arguments:
+#### Arguments
 
-- `index`: Index in `props.items` of the newly selected item
-- `items`: `props.items`
+- `index` (`Number`): Index of the newly selected item in `props.items`.
+- `items` (`Array`): the items passed in `props.items`.
 
-### `wide`
+### selected
 
-- Type: `Boolean`
-- Default: `false`
+| Type     | Default value |
+| -------- | ------------- |
+| `Number` | `-1`          |
+
+Set this prop to the index of the active item. Set to `-1` to unselect and
+display the placeholder.
+
+### wide
+
+| Type      | Default value |
+| --------- | ------------- |
+| `Boolean` | `false`       |
 
 Takes the full width if set to `true`.
+
+### width
+
+| Type     | Default value |
+| -------- | ------------- |
+| `String` | None          |
+
+Use this prop to set the CSS width of the button.


### PR DESCRIPTION
## Changes
- `label` is going to be deprecated and is now renamed to `placeholder`.
- `renderLabel` prop has been added to force display. An example use case is to force display a shorten address instead of the whole address.
- `wide` prop has been added again (was missing since the `newstyle` implementation).
- Update docs.