### PR TITLE
Fix CardLayout on medium and large layouts

### DIFF
--- a/devbox/apps/Card.js
+++ b/devbox/apps/Card.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import {
+  Header,
+  Layout,
+  Bar,
+  Box,
+  Button,
+  BackButton,
+  Card,
+  CardLayout,
+  Split,
+  Tabs,
+  Theme,
+  useLayout,
+  IconPlus,
+} from '@aragon/ui'
+import { ToggleThemeButton } from '../components/toggle-theme'
+
+function Cards({ count = 10, interactive }) {
+  const cardProps = interactive ? { onClick: () => {} } : {}
+  return (
+    <CardLayout>
+      {[...Array(count)].map((v, i) => (
+        <Card key={i} {...cardProps} />
+      ))}
+    </CardLayout>
+  )
+}
+
+export default () => {
+  return (
+    <>
+      <Header
+        primary="Voting"
+        secondary={
+          <Button mode="strong" label="New vote" icon={<IconPlus />} />
+        }
+      />
+      <Bar />
+      <Cards count={1} />
+      <Cards count={2} />
+      <Cards count={3} />
+      <Cards count={4} />
+      <Cards count={5} />
+      <Cards count={10} />
+    </>
+  )
+}

--- a/src/components/CardLayout/CardLayout.js
+++ b/src/components/CardLayout/CardLayout.js
@@ -21,12 +21,12 @@ function CardLayout({ children, columnWidthMin, rowHeight, ...props }) {
           display: grid;
           grid-gap: ${2 * GU}px;
           grid-auto-flow: row;
-          align-items: start;
           grid-template-columns: repeat(
-            auto-fit,
+            ${fullWidth ? 'auto-fit' : 'auto-fill'},
             minmax(${columnWidthMin}px, 1fr)
           );
           grid-auto-rows: ${rowHeight}px;
+          align-items: start;
           padding: 0 ${fullWidth ? 2 * GU : 0}px ${3 * GU}px;
           margin: 0 auto;
         `}


### PR DESCRIPTION
Still looking for a solution on small layouts, where cards would have a minimum width and a maximum width, and the minimum width would be preferred by the layout algorithm (`minmax()` prefers the max value since `fr` can not be used as a first argument). See https://github.com/w3c/csswg-drafts/issues/2611

Other solutions:

- [`min()`](https://developer.mozilla.org/en-US/docs/Web/CSS/min) or [`clamp()`](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp), which are not supported yet.
- Using Flexbox on the small layout (which would allow `min-width` / `max-width`). Since we are using fixed heights, this might be the easiest solution.
- JS calculations using `Viewport` and `Layout`, passing the calculated dimensions to the children `Card` using context.