### PR TITLE
Web3: always lowercase tokenIconUrl addresses when creating icon URL

### DIFF
--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -142,7 +142,7 @@ export function blockExplorerUrl(
  * @return {string} The generated URL, or an empty string if the parameters are invalid.
  */
 export function tokenIconUrl(address = '') {
-  address = address.trim()
+  address = address.trim().toLowerCase()
   return address
     ? `https://raw.githubusercontent.com/TrustWallet/tokens/master/tokens/${address}.png`
     : ''


### PR DESCRIPTION
TrustWallet's repo has the token addresses all lower cased, so we should do the same to `tokenIconUrl()`'s address argument :).