### PR TITLE
Dropdown: newstyle tweaks

### DIFF
--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { Button } from '../Button/Button'
 import { ButtonBase } from '../Button/ButtonBase'
 import Popover from '../Popover/Popover'
 import { IconDown } from '../../icons'
@@ -157,17 +156,22 @@ const DropDown = React.memo(function DropDown({
 
   return (
     <React.Fragment>
-      <Button
+      <ButtonBase
         ref={refCallback}
         onClick={handleToggle}
+        focusRingRadius={RADIUS}
         css={`
           display: ${wide ? 'flex' : 'inline-flex'};
           justify-content: space-between;
           align-items: center;
+          height: ${6 * GU}px;
           padding: 0 ${2 * GU}px;
           width: ${width || (wide ? '100%' : 'auto')};
-          min-width: unset;
-          ${closedWithChanges ? `border: 1px solid ${theme.accent}` : ''}
+          background: ${theme.surface};
+          border: 1px solid ${closedWithChanges ? theme.selected : theme.border};
+          &:active {
+            background: ${theme.surfacePressed};
+          }
         `}
       >
         <span
@@ -187,12 +191,13 @@ const DropDown = React.memo(function DropDown({
             ${closedWithChanges ? `color: ${theme.accent}` : ''}
           `}
         />
-      </Button>
+      </ButtonBase>
       <Popover
         visible={opened}
         onClose={handleClose}
         opener={buttonRef.current}
         placement="bottom-start"
+        scaleEffect={false}
       >
         <div
           css={`

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -140,7 +140,7 @@ class PopoverBase extends React.Component {
   }
 
   render() {
-    const { zIndex, children, transitionStyles, theme } = this.props
+    const { zIndex, children, transitionStyles, theme, ...props } = this.props
     const { scale, opacity } = transitionStyles
     return (
       <animated.div
@@ -171,6 +171,7 @@ class PopoverBase extends React.Component {
               outline: 0;
             }
           `}
+          {...props}
         >
           {children}
         </animated.div>
@@ -179,36 +180,43 @@ class PopoverBase extends React.Component {
   }
 }
 
-const Popover = props => (
-  <RootPortal>
-    <Transition
-      items={props.visible}
-      config={springs.swift}
-      from={{ scale: 0.9, opacity: 0 }}
-      enter={{ scale: 1, opacity: 1 }}
-      leave={{ scale: 0.9, opacity: 0 }}
-      native
-    >
-      {visible =>
-        visible &&
-        (transitionStyles => (
-          <PopoverBase {...props} transitionStyles={transitionStyles} />
-        ))
-      }
-    </Transition>
-  </RootPortal>
-)
+function Popover({ scaleEffect, visible, ...props }) {
+  const theme = useTheme()
+  return (
+    <RootPortal>
+      <Transition
+        items={visible}
+        config={springs.swift}
+        from={{ scale: scaleEffect ? 0.9 : 1, opacity: 0 }}
+        enter={{ scale: 1, opacity: 1 }}
+        leave={{ scale: scaleEffect ? 0.9 : 1, opacity: 0 }}
+        native
+      >
+        {visible =>
+          visible &&
+          (transitionStyles => (
+            <PopoverBase
+              {...props}
+              theme={theme}
+              transitionStyles={transitionStyles}
+            />
+          ))
+        }
+      </Transition>
+    </RootPortal>
+  )
+}
 
 Popover.propTypes = {
   ...PopoverBase.propTypes,
+  scaleEffect: PropTypes.bool,
   visible: PropTypes.bool,
 }
+
 Popover.defaultProps = {
   ...PopoverBase.defaultProps,
+  scaleEffect: true,
   visible: true,
 }
 
-export default props => {
-  const theme = useTheme()
-  return <Popover theme={theme} {...props} />
-}
+export default Popover

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -34,7 +34,9 @@ function App() {
 
 ### `opener`
 
-- Type: `DOMNode`
+| Type          | Default value |
+| ------------- | ------------- |
+| `DOM Element` | null          |
 
 Reference to the "opener"which is what the Popover is positioning relative to.
 
@@ -47,12 +49,32 @@ Placement of the Popover relative to the "opener". Checkout [Popper.js](https://
 
 ### `zIndex`
 
-- Type: `number`
+| Type     | Default value |
+| -------- | ------------- |
+| `Number` | 999           |
 
 zIndex of Popover.
 
 ### `onClose`
 
-- Type: `function`
+| Type       | Default value |
+| ---------- | ------------- |
+| `Function` | None          |
 
 The callback that is called when the popover request to be closed.
+
+### `visible`
+
+| Type      | Default value |
+| --------- | ------------- |
+| `Boolean` | `true`        |
+
+Whether or not the Popover is visible.
+
+### `scaleEffect`
+
+| Type      | Default value |
+| --------- | ------------- |
+| `Boolean` | `true`        |
+
+Set to `false` to disable the scaling effect when the popover appears and disappears.


### PR DESCRIPTION
- Use a border rather than a shadow, for the button and the popup menu.
- Use `theme.surfacePressed` for the pressed state of the button.
- For the selected mode, use `theme.selected` (rather than `theme.accent`).
- Do not scale the popover during the opening transition.
- Popover now passes its props down to the main element.