### PR TITLE
Inside: allow additional data to be passed

### DIFF
--- a/src/components/BackButton/BackButton.js
+++ b/src/components/BackButton/BackButton.js
@@ -9,7 +9,7 @@ import { IconArrowLeft } from '../../icons'
 
 function BackButton({ label, ...props }) {
   const theme = useTheme()
-  const insideBarPrimary = useInside('Bar:primary')
+  const [insideBarPrimary] = useInside('Bar:primary')
 
   return (
     <ButtonBase

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -95,8 +95,8 @@ function Button({
   const theme = useTheme()
   const { layoutName } = useLayout()
 
-  const insideEmptyStateCard = useInside('EmptyStateCard')
-  const insideHeaderSecondary = useInside('Header:secondary')
+  const [insideEmptyStateCard] = useInside('EmptyStateCard')
+  const [insideHeaderSecondary] = useInside('Header:secondary')
 
   // Always wide + strong when used as an empty state card action
   if (insideEmptyStateCard) {

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types'
 import { css } from 'styled-components'
 import { GU, RADIUS } from '../../style'
 import { useTheme } from '../../theme'
-import { unselectable } from '../../utils'
-import { useInsideCardLayout } from '../CardLayout/CardLayout'
+import { unselectable, useInside } from '../../utils'
 import FocusVisible from '../FocusVisible/FocusVisible'
 
 const DEFAULT_WIDTH = 35 * GU
@@ -22,7 +21,7 @@ function dimension(insideCardLayout, value, defaultValue) {
 
 function Card({ children, width, height, onClick, ...props }) {
   const theme = useTheme()
-  const insideCardLayout = useInsideCardLayout()
+  const [insideCardLayout] = useInside('CardLayout')
   const interactive = Boolean(onClick)
 
   const interactiveProps = interactive

--- a/src/components/CardLayout/CardLayout.js
+++ b/src/components/CardLayout/CardLayout.js
@@ -1,21 +1,15 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { GU } from '../../style'
 import { useLayout } from '../Layout/Layout'
-
-const CardLayoutContext = React.createContext(false)
-
-// Returns true if a component is declared inside of the CardLayout tree
-function useInsideCardLayout() {
-  return useContext(CardLayoutContext)
-}
+import { Inside } from '../../utils/inside'
 
 function CardLayout({ children, columnWidthMin, rowHeight, ...props }) {
   const { layoutName } = useLayout()
   const fullWidth = layoutName === 'small'
 
   return (
-    <CardLayoutContext.Provider value={true}>
+    <Inside name="CardLayout">
       <div
         css={`
           display: grid;
@@ -34,7 +28,7 @@ function CardLayout({ children, columnWidthMin, rowHeight, ...props }) {
       >
         {children}
       </div>
-    </CardLayoutContext.Provider>
+    </Inside>
   )
 }
 
@@ -49,5 +43,5 @@ CardLayout.defaultProps = {
   rowHeight: 21 * GU,
 }
 
-export { CardLayout, useInsideCardLayout }
+export { CardLayout }
 export default CardLayout

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -172,8 +172,8 @@ function FocusRing() {
 export default props => {
   const { layoutName } = useLayout()
 
-  const insideBar = useInside('Bar')
-  const insideAppBar = useInside('AppBar')
+  const [insideBar] = useInside('Bar')
+  const [insideAppBar] = useInside('AppBar')
 
   // Use a separate component for Tabs in AppBar, to prevent breaking anything.
   if (insideAppBar) {

--- a/src/utils/inside.js
+++ b/src/utils/inside.js
@@ -33,9 +33,9 @@ Inside.propTypes = {
 
 // Use this hook to know if a given component is somewhere
 // in the tree of an <Inside> declared with the same name.
-function useInside(name, withData) {
+function useInside(name) {
   const { inside, data } = useContext(getContext(name))
-  return withData ? [inside, data] : inside
+  return [inside, data]
 }
 
 export { Inside, useInside }

--- a/src/utils/inside.js
+++ b/src/utils/inside.js
@@ -10,26 +10,32 @@ const insideContexts = new Map()
 // Creates the required context if it doesn’t exist.
 function getContext(name) {
   if (!insideContexts.has(name)) {
-    insideContexts.set(name, React.createContext(false))
+    insideContexts.set(name, React.createContext({ inside: false, data: null }))
   }
   return insideContexts.get(name)
 }
 
 // Use this component to declare a new “inside context”, by name.
-function Inside({ name, children }) {
+function Inside({ children, data, name }) {
   const Context = getContext(name)
-  return <Context.Provider value={true}>{children}</Context.Provider>
+  return (
+    <Context.Provider value={{ inside: true, data }}>
+      {children}
+    </Context.Provider>
+  )
 }
 
 Inside.propTypes = {
-  name: PropTypes.string.isRequired,
   children: PropTypes.node,
+  data: PropTypes.any,
+  name: PropTypes.string.isRequired,
 }
 
 // Use this hook to know if a given component is somewhere
 // in the tree of an <Inside> declared with the same name.
-function useInside(name) {
-  return useContext(getContext(name))
+function useInside(name, withData) {
+  const { inside, data } = useContext(getContext(name))
+  return withData ? [inside, data] : inside
 }
 
 export { Inside, useInside }


### PR DESCRIPTION
This is useful to pass some data from the parent component to the consumers.

Consumer:

```jsx
// like before
const insideSomething = useInside('Something')

// pass true as a second parameter to get the optional data
const [insideSomething, somethingData] = useInside('Something', true)
```

Provider:

```jsx
// data can take any value
function Something({ children }) {
  return (
    <Inside name="Something" data={{ hey: 'hey hey' }}>
      {children}
    </Inside>
  )
}
```