### PR TITLE
DropDown: disabled mode

### DIFF
--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -164,7 +164,7 @@ const DropDown = React.memo(function DropDown({
           display: ${wide ? 'flex' : 'inline-flex'};
           justify-content: space-between;
           align-items: center;
-          height: ${6 * GU}px;
+          height: ${5 * GU}px;
           padding: 0 ${2 * GU}px;
           width: ${width || (wide ? '100%' : 'auto')};
           background: ${theme.surface};

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -186,8 +186,6 @@ const DropDown = React.memo(function DropDown({
           size="tiny"
           css={`
             margin-left: ${1 * GU}px;
-            transition: transform 0.3s;
-            transform: rotate3d(0, 0, 1, ${opened ? 180 : 0}deg);
             ${closedWithChanges ? `color: ${theme.accent}` : ''}
           `}
         />
@@ -196,8 +194,6 @@ const DropDown = React.memo(function DropDown({
         visible={opened}
         onClose={handleClose}
         opener={buttonRef.current}
-        placement="bottom-start"
-        scaleEffect={false}
       >
         <div
           css={`

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -174,7 +174,7 @@ const DropDown = React.memo(function DropDown({
           border: ${disabled ? 0 : 1}px solid
             ${closedWithChanges ? theme.selected : theme.border};
           ${textStyle('body2')};
-
+          ${disabled && 'font-weight: 600;'}
           ${!disabled &&
             `
               &:active {

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -83,11 +83,12 @@ function useButtonRef(cb) {
 }
 
 const DropDown = React.memo(function DropDown({
+  disabled,
   header,
   items,
+  onChange,
   placeholder,
   renderLabel,
-  onChange,
   selected,
   wide,
   width,
@@ -158,8 +159,9 @@ const DropDown = React.memo(function DropDown({
     <React.Fragment>
       <ButtonBase
         ref={refCallback}
-        onClick={handleToggle}
+        disabled={disabled}
         focusRingRadius={RADIUS}
+        onClick={handleToggle}
         css={`
           display: ${wide ? 'flex' : 'inline-flex'};
           justify-content: space-between;
@@ -167,26 +169,26 @@ const DropDown = React.memo(function DropDown({
           height: ${5 * GU}px;
           padding: 0 ${2 * GU}px;
           width: ${width || (wide ? '100%' : 'auto')};
-          background: ${theme.surface};
-          border: 1px solid ${closedWithChanges ? theme.selected : theme.border};
-          &:active {
-            background: ${theme.surfacePressed};
-          }
+          background: ${disabled ? theme.disabled : theme.surface};
+          color: ${disabled ? theme.disabledContent : theme.surfaceContent};
+          border: ${disabled ? 0 : 1}px solid
+            ${closedWithChanges ? theme.selected : theme.border};
+          ${textStyle('body2')};
+
+          ${!disabled &&
+            `
+              &:active {
+                background: ${theme.surfacePressed};
+              }
+          `}
         `}
       >
-        <span
-          css={`
-            color: ${theme.content};
-            ${textStyle('body2')};
-          `}
-        >
-          <Label selectedIndex={selectedIndex} selectedLabel={selectedLabel} />
-        </span>
+        <Label selectedIndex={selectedIndex} selectedLabel={selectedLabel} />
         <IconDown
           size="tiny"
           css={`
             margin-left: ${1 * GU}px;
-            ${closedWithChanges ? `color: ${theme.accent}` : ''}
+            color: ${closedWithChanges && !disabled ? theme.accent : 'inherit'};
           `}
         />
       </ButtonBase>
@@ -241,6 +243,7 @@ const DropDown = React.memo(function DropDown({
 })
 
 DropDown.propTypes = {
+  disabled: PropTypes.bool,
   header: PropTypes.node,
   items: PropTypes.arrayOf(PropTypes.node).isRequired,
   onChange: PropTypes.func.isRequired,

--- a/src/components/DropDown/README.md
+++ b/src/components/DropDown/README.md
@@ -95,3 +95,11 @@ Takes the full width if set to `true`.
 | `String` | None          |
 
 Use this prop to set the CSS width of the button.
+
+### disabled
+
+| Type      | Default value |
+| --------- | ------------- |
+| `Boolean` | `false`       |
+
+Disable the DropDown.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36158/62884731-7d076b80-bd37-11e9-99e8-b74ee592798e.png)

@dizzypaty @owisixseven This is a proposition for a disabled state on DropDown, following the same style we use for disabled buttons (https://github.com/aragon/aragon-ui/pull/432). Please let me know if it works!
