### PR TITLE
Popover: ignore onClose() if focus is on opener

### DIFF
--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -20,11 +20,7 @@ function useDropDown({
   const [opened, setOpened] = useState(false)
 
   const close = useCallback(() => {
-    // if the popover is opened and the user clicks on the button
-    // this handler was being called before the click handler, so the
-    // click handler was re-opening the popover, by having this on the
-    // next tick things happen in order.
-    setTimeout(() => setOpened(false), 10)
+    setOpened(false)
 
     if (buttonRef.current) {
       buttonRef.current.focus()

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -188,7 +188,12 @@ const DropDown = React.memo(function DropDown({
           `}
         />
       </ButtonBase>
-      <Popover visible={opened} onClose={close} opener={buttonRef.current}>
+      <Popover
+        closeOnOpenerFocus
+        onClose={close}
+        opener={buttonRef.current}
+        visible={opened}
+      >
         <div
           css={`
             min-width: ${buttonWidth}px;

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -127,7 +127,11 @@ class PopoverBase extends React.Component {
   handleBlur = event => {
     const { opener, onClose } = this.props
     const focusedElement = event.relatedTarget
-    if (this._cardElement.current.contains(focusedElement)) {
+    if (
+      (this._cardElement.current &&
+        this._cardElement.current.contains(focusedElement)) ||
+      (opener && opener.contains(focusedElement))
+    ) {
       return
     }
 

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -9,6 +9,7 @@ import RootPortal from '../RootPortal/RootPortal'
 
 class PopoverBase extends React.Component {
   static propTypes = {
+    closeOnOpenerFocus: PropTypes.bool,
     opener: PropTypes.instanceOf(Element),
     placement: PropTypes.oneOf(
       // "center" is a value that doesn’t exist in Popper, but we are using it
@@ -29,6 +30,7 @@ class PopoverBase extends React.Component {
   }
 
   static defaultProps = {
+    closeOnOpenerFocus: false,
     opener: null,
     placement: 'center',
     onClose: noop,
@@ -125,12 +127,16 @@ class PopoverBase extends React.Component {
   }
 
   handleBlur = event => {
-    const { opener, onClose } = this.props
+    const { closeOnOpenerFocus, opener, onClose } = this.props
     const focusedElement = event.relatedTarget
+
+    // Do not close if:
+    // - The blur event is emitted from an element inside of the popover.
+    // - The focused target is the opener and closeOnOpenerFocus is true.
     if (
       (this._cardElement.current &&
         this._cardElement.current.contains(focusedElement)) ||
-      (opener && opener.contains(focusedElement))
+      (closeOnOpenerFocus && opener && opener.contains(focusedElement))
     ) {
       return
     }

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -46,7 +46,7 @@ Reference to the "opener"which is what the Popover is positioning relative to.
 | --------- | ------------- |
 | `Boolean` | `false`       |
 
-Do not immediatly reopen the Popover when the opener gets focused while being opened, making it possible to toggle its visibility from the opener, if its placement allows it.
+While the Popover is opened, do not immediately close the Popover when the opener gets focused. This makes it possible to toggle its visibility from the opener, if its placement allows it.
 
 ### `placement`
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -40,6 +40,14 @@ function App() {
 
 Reference to the "opener"which is what the Popover is positioning relative to.
 
+### `closeOnOpenerFocus`
+
+| Type      | Default value |
+| --------- | ------------- |
+| `Boolean` | `false`       |
+
+Do not immediatly reopen the Popover when the opener gets focused while being opened, making it possible to toggle its visibility from the opener, if its placement allows it.
+
 ### `placement`
 
 - Type: `String`


### PR DESCRIPTION
There's a lot of cases where we set toggle functionality on the opener, and this doesn't play nicely with the blur handler on the popper (resulting in difficult-to-fix race conditions with the handlers). For an example, the current [DropDown](https://devbox.dweb.cool/#DropDown) has this problem.

Perhaps this should be protected behind a prop, since it could be a bit surprising if you expected the `onClose()` to always be fired when the Popover closes.

Fixes #477