### PR TITLE
Layout breakpoints

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -30,7 +30,7 @@ function getLayoutSize(parentWidth, breakpoints) {
 
 const LayoutContext = React.createContext({})
 
-function useLayout(parentWidth) {
+function useLayout() {
   const { layoutWidth, layoutName } = useContext(LayoutContext)
   return {
     layoutName,

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -35,6 +35,8 @@ function useLayout() {
   return {
     layoutName,
     layoutWidth,
+
+    // deprecated
     name: layoutName,
     width: layoutWidth,
   }


### PR DESCRIPTION
This is an advanced prop that shouldn’t be used by apps. It is used in the onboarding at the moment, which has smaller breakpoints but still use `Split` and similar components.