### PR TITLE
TextInput: use normal border colour when focused in readonly mode

### DIFF
--- a/src/components/Input/TextInput.js
+++ b/src/components/Input/TextInput.js
@@ -39,6 +39,7 @@ const TextInput = React.forwardRef(({ multiline, type, ...props }, ref) => {
         &:read-only {
           color: transparent;
           text-shadow: 0 0 0 ${theme.surfaceContentSecondary};
+          border-color: ${theme.border};
         }
       `}
     />


### PR DESCRIPTION
It's weird that the focus state would cause an active border if the input is readonly:

<img width="574" alt="Screen Shot 2019-08-15 at 3 02 13 PM" src="https://user-images.githubusercontent.com/4166642/63096276-d48f1c80-bf6d-11e9-9132-d4e047fcd895.png">
