### PR TITLE
Style: prefer ternary declarations in dynamic styled-components

### DIFF
--- a/src/components/AddressField/AddressField.js
+++ b/src/components/AddressField/AddressField.js
@@ -88,7 +88,7 @@ class AddressFieldBase extends React.PureComponent {
             border: 0;
             box-shadow: none;
             background: transparent;
-            ${icon && 'padding-left: 8px'};
+            ${icon ? 'padding-left: 8px' : ''};
             ${font({ monospace: true })};
             &:read-only {
               color: ${theme.textPrimary};

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -169,13 +169,14 @@ const DropDown = React.memo(function DropDown({
           border: ${disabled ? 0 : 1}px solid
             ${closedWithChanges ? theme.selected : theme.border};
           ${textStyle('body2')};
-          ${disabled && 'font-weight: 600;'}
-          ${!disabled &&
-            `
+          ${disabled ? 'font-weight: 600;' : ''}
+          ${!disabled
+            ? `
               &:active {
                 background: ${theme.surfacePressed};
               }
-          `}
+          `
+            : ''}
         `}
         {...props}
       >
@@ -286,13 +287,22 @@ const Item = React.memo(function Item({
           color: ${theme.content};
 
           ${textStyle('body2')};
-          ${!header && index === 0 && `border-top-left-radius: ${RADIUS}px;`}
-          ${index === length - 1 && `border-bottom-left-radius: ${RADIUS}px;`}
-          ${selected === index &&
-            `
+          ${
+            !header && index === 0 ? `border-top-left-radius: ${RADIUS}px;` : ''
+          }
+          ${
+            index === length - 1
+              ? `border-bottom-left-radius: ${RADIUS}px;`
+              : ''
+          }
+          ${
+            selected === index
+              ? `
               border-left: 2px solid ${theme.accent};
               background: ${theme.surfaceSelected};
-            `}
+            `
+              : ''
+          }
 
           &:active {
             background: ${theme.surfacePressed};

--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -71,7 +71,7 @@ class IdentityBadge extends React.PureComponent {
             color: ${theme.textPrimary};
             height: 24px;
             &:active {
-              ${compact && 'background: rgba(220, 234, 239, 0.3);'};
+              ${compact ? 'background: rgba(220, 234, 239, 0.3);' : ''};
             }
           `}
         >
@@ -92,7 +92,7 @@ class IdentityBadge extends React.PureComponent {
                 css={`
                   display: block;
                   margin-right: -3px;
-                  ${compact && 'position: relative; top: -1px;'};
+                  ${compact ? 'position: relative; top: -1px;' : ''};
                 `}
               >
                 <EthIdenticon

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -139,7 +139,7 @@ function Tag({
         justify-content: center;
         white-space: nowrap;
         ${sizeStyles};
-        ${!uppercase && 'text-transform: unset'};
+        ${!uppercase ? 'text-transform: unset' : ''};
         color: ${color || modeProps.color};
         background: ${background || modeProps.background};
         ${unselectable};


### PR DESCRIPTION
I've since learned that passing around booleans in declaring styled-components can lead to these errors:

<img width="468" alt="Screen Shot 2019-08-16 at 12 59 44 PM" src="https://user-images.githubusercontent.com/4166642/63185009-2d87af00-c059-11e9-852b-2d06e76c383d.png">

As you said @AquiGorka, it is preferable to use the ternary syntax :).

These components generally don't error, but we may as well use this syntax consistently when defining dynamically styled styled-components.