### PR TITLE
Tabs: update border colour when in full width mode

### DIFF
--- a/src/components/Tabs/TabsFullWidth.js
+++ b/src/components/Tabs/TabsFullWidth.js
@@ -72,7 +72,7 @@ function TabsFullWidth({ items, selected, onChange }) {
             height: 100%;
             background: ${theme.surface};
             border-style: solid;
-            border-color: ${theme.border};
+            border-color: ${theme.border.alpha(0.5)};
             border-top-width: ${insideSidePanel ? '0' : '1px'};
             border-bottom-width: 1px;
             border-radius: 0;


### PR DESCRIPTION
Updates the `Tabs`'s full width version to use a lighter border-colour.

Not too sure, but this seems consistent in most of the design files I've seen (e.g. [this one for Permissions](https://www.figma.com/file/VmfsSnRMDlxcmxTmHP1WwiLR/Permissions?node-id=4%3A12009)).