### PR TITLE
Tag: tweak the vertical alignment

### DIFF
--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -157,14 +157,19 @@ function Tag({
           css={`
             display: flex;
             align-items: center;
-            margin-top: ${alignmentCorrection ? '-2px' : '0'};
             margin-right: ${finalLabel ? 0.25 * GU : 0}px;
           `}
         >
           {icon}
         </span>
       )}
-      {finalLabel}
+      <span
+        css={`
+          margin-top: ${alignmentCorrection ? '1px' : '0'};
+        `}
+      >
+        {finalLabel}
+      </span>
     </span>
   )
 }

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -131,6 +131,12 @@ function Tag({
     iconAndLabel: icon && finalLabel,
   })
 
+  // Slightly tweak the alignment when there are no descenders,
+  // to make the characters look more aligned.
+  const alignmentCorrection =
+    finalSize === SIZE_NORMAL &&
+    (uppercase || typeof label === 'number' || limitDigits !== false)
+
   return (
     <span
       css={`
@@ -151,7 +157,7 @@ function Tag({
           css={`
             display: flex;
             align-items: center;
-            margin-top: ${finalSize === SIZE_NORMAL ? '-3px' : '0'};
+            margin-top: ${alignmentCorrection ? '-2px' : '0'};
             margin-right: ${finalLabel ? 0.25 * GU : 0}px;
           `}
         >


### PR DESCRIPTION
From `3px` to ~`2px`~ `1px`, also making sure it only applies when there are no [descenders](https://en.wikipedia.org/wiki/Descender).

**Edit:** also apply the alignment to the text, not the icon :man_facepalming: 