### PR TITLE
Add a babel plugin to handle the gu unit

### DIFF
--- a/babel-plugin-aragon-ui/.babelrc
+++ b/babel-plugin-aragon-ui/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": 4
+        }
+      }
+    ]
+  ]
+}

--- a/babel-plugin-aragon-ui/.gitignore
+++ b/babel-plugin-aragon-ui/.gitignore
@@ -1,0 +1,2 @@
+/lib/
+node_modules/

--- a/babel-plugin-aragon-ui/README.md
+++ b/babel-plugin-aragon-ui/README.md
@@ -1,0 +1,22 @@
+# babel-plugin-aragon-ui
+
+Plugin greatly inspired from [babel-plugin-styled-components](https://github.com/styled-components/babel-plugin-styled-components), and made to work with it.
+
+## Features
+
+- Adds the `gu` unit to styled component’s CSS blocks (in normal styled
+  components, in the `css` prop, or using the `css` helper).
+- That’s all for now.
+
+## Installation
+
+In your .babelrc, declare this plugin before styled-components:
+
+```json
+{
+  "plugins": [
+    "@aragon/babel-plugin-aragon-ui",
+    "styled-components"
+  ]
+}
+```

--- a/babel-plugin-aragon-ui/package.json
+++ b/babel-plugin-aragon-ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@aragon/babel-plugin-aragon-ui",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "babel src -d lib"
+  },
+  "dependencies": {
+    "babel-plugin-syntax-jsx": "^6.18.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5"
+  }
+}

--- a/babel-plugin-aragon-ui/src/gu.js
+++ b/babel-plugin-aragon-ui/src/gu.js
@@ -1,0 +1,53 @@
+import { isStyled, isHelper } from './utils/detectors'
+
+const GU = 8
+const GU_REGEX = /([^0-9a-zA-Z])((-?[0-9]*\.?[0-9]+)gu)/gm
+
+function guReplacer(match, p1, p2, p3) {
+  const value = parseInt(p3, 10)
+  if (isNaN(value)) {
+    return match
+  }
+  return `${p1}${value * GU}px`
+}
+
+function replaceGus(value) {
+  return value.replace(GU_REGEX, guReplacer)
+}
+
+// Transform a styled component or helper (e.g. css``)
+export function guStyledComponent(t, path, state) {
+  if (isStyled(t)(path.node.tag, state) || isHelper(t)(path.node.tag, state)) {
+    path.node.quasi.quasis.forEach(element => {
+      element.value.raw = replaceGus(element.value.raw)
+      element.value.cooked = replaceGus(element.value.cooked)
+    })
+  }
+}
+
+// Transform the css prop
+export function guCss(t, path, state) {
+  if (path.node.name.name !== 'css') {
+    return
+  }
+
+  // css="width: 10gu"
+  if (t.isStringLiteral(path.node.value)) {
+    path.node.value.value = replaceGus(path.node.value.value)
+    return
+  }
+
+  // css={`
+  //   width: 10gu;
+  // `}
+  if (
+    t.isJSXExpressionContainer(path.node.value) &&
+    t.isTemplateLiteral(path.node.value.expression)
+  ) {
+    path.node.value.expression.quasis.forEach(element => {
+      element.value.raw = replaceGus(element.value.raw)
+      element.value.cooked = replaceGus(element.value.cooked)
+    })
+    return
+  }
+}

--- a/babel-plugin-aragon-ui/src/index.js
+++ b/babel-plugin-aragon-ui/src/index.js
@@ -1,0 +1,23 @@
+import syntax from 'babel-plugin-syntax-jsx'
+import { guStyledComponent, guCss } from './gu'
+
+export default function({ types: t }) {
+  return {
+    inherits: syntax,
+    visitor: {
+      Program(path, state) {
+        path.traverse(
+          {
+            JSXAttribute(path, state) {
+              guCss(t, path, state)
+            },
+          },
+          state
+        )
+      },
+      TaggedTemplateExpression(path, state) {
+        guStyledComponent(t, path, state)
+      },
+    },
+  }
+}

--- a/babel-plugin-aragon-ui/src/utils/detectors.js
+++ b/babel-plugin-aragon-ui/src/utils/detectors.js
@@ -1,0 +1,112 @@
+const VALID_TOP_LEVEL_IMPORT_PATHS = [
+  'styled-components',
+  'styled-components/no-tags',
+  'styled-components/native',
+  'styled-components/primitives',
+]
+
+export const isValidTopLevelImport = x =>
+  VALID_TOP_LEVEL_IMPORT_PATHS.includes(x)
+
+const localNameCache = {}
+
+export const importLocalName = (name, state, bypassCache = false) => {
+  const cacheKey = name + state.file.opts.filename
+
+  if (!bypassCache && cacheKey in localNameCache) {
+    return localNameCache[cacheKey]
+  }
+
+  let localName = state.styledRequired
+    ? name === 'default'
+      ? 'styled'
+      : name
+    : false
+
+  state.file.path.traverse({
+    ImportDeclaration: {
+      exit(path) {
+        const { node } = path
+
+        if (isValidTopLevelImport(node.source.value)) {
+          for (const specifier of path.get('specifiers')) {
+            if (specifier.isImportDefaultSpecifier()) {
+              localName = specifier.node.local.name
+            }
+
+            if (
+              specifier.isImportSpecifier() &&
+              specifier.node.imported.name === name
+            ) {
+              localName = specifier.node.local.name
+            }
+
+            if (specifier.isImportNamespaceSpecifier()) {
+              localName = specifier.node.local.name
+            }
+          }
+        }
+      },
+    },
+  })
+
+  localNameCache[cacheKey] = localName
+
+  return localName
+}
+
+export const isStyled = t => (tag, state) => {
+  if (
+    t.isCallExpression(tag) &&
+    t.isMemberExpression(tag.callee) &&
+    tag.callee.property.name !== 'default' /** ignore default for #93 below */
+  ) {
+    // styled.something()
+    return isStyled(t)(tag.callee.object, state)
+  } else {
+    return (
+      (t.isMemberExpression(tag) &&
+        tag.object.name === importLocalName('default', state)) ||
+      (t.isCallExpression(tag) &&
+        tag.callee.name === importLocalName('default', state)) ||
+      /**
+       * #93 Support require()
+       * styled-components might be imported using a require()
+       * call and assigned to a variable of any name.
+       * - styled.default.div``
+       * - styled.default.something()
+       */
+      (state.styledRequired &&
+        t.isMemberExpression(tag) &&
+        t.isMemberExpression(tag.object) &&
+        tag.object.property.name === 'default' &&
+        tag.object.object.name === state.styledRequired) ||
+      (state.styledRequired &&
+        t.isCallExpression(tag) &&
+        t.isMemberExpression(tag.callee) &&
+        tag.callee.property.name === 'default' &&
+        tag.callee.object.name === state.styledRequired)
+    )
+  }
+}
+
+export const isCSSHelper = t => (tag, state) =>
+  t.isIdentifier(tag) && tag.name === importLocalName('css', state)
+
+export const isCreateGlobalStyleHelper = t => (tag, state) =>
+  t.isIdentifier(tag) &&
+  tag.name === importLocalName('createGlobalStyle', state)
+
+export const isInjectGlobalHelper = t => (tag, state) =>
+  t.isIdentifier(tag) && tag.name === importLocalName('injectGlobal', state)
+
+export const isKeyframesHelper = t => (tag, state) =>
+  t.isIdentifier(tag) && tag.name === importLocalName('keyframes', state)
+
+export const isHelper = t => (tag, state) =>
+  isCSSHelper(t)(tag, state) || isKeyframesHelper(t)(tag, state)
+
+export const isPureHelper = t => (tag, state) =>
+  isCSSHelper(t)(tag, state) ||
+  isKeyframesHelper(t)(tag, state) ||
+  isCreateGlobalStyleHelper(t)(tag, state)

--- a/babel-plugin-aragon-ui/src/utils/detectors.js
+++ b/babel-plugin-aragon-ui/src/utils/detectors.js
@@ -1,3 +1,6 @@
+// Copied from
+// https://github.com/styled-components/babel-plugin-styled-components/blob/master/src/utils/detectors.js
+
 const VALID_TOP_LEVEL_IMPORT_PATHS = [
   'styled-components',
   'styled-components/no-tags',


### PR DESCRIPTION
See discussion: https://github.com/aragon/aragon-ui/issues/333

# babel-plugin-aragon-ui

Plugin greatly inspired from [babel-plugin-styled-components](https://github.com/styled-components/babel-plugin-styled-components), and made to work with it.

## What it does

Transforms this:

```jsx
<div
  css={`
    width: 4gu;
    height: 4gu;
  `}
/>
```

Into this:

```jsx
<div
  css={`
    width: 32px;
    height: 32px;
  `}
/>
```

## Features

- Adds the `gu` unit to styled component’s CSS blocks (in normal styled
  components, in the `css` prop, or using the `css` helper).

## Installation

In your .babelrc, declare this plugin before styled-components:

```json
{
  "plugins": [
    "@aragon/babel-plugin-aragon-ui",
    "styled-components"
  ]
}
```

## To do

- Support for text styles: `-ui-text-style: title1`
- Support for theme values: `-ui-theme(surfaceContent)`

Note: both are using the [CSS syntax for proprietary extensions](https://www.w3.org/TR/CSS22/syndata.html#vendor-keywords), but we might as well decide to drop them, or not follow it exactly (e.g. by removing the initial `-`).