### PR TITLE
DateRange: adjust input field styling

### DIFF
--- a/src/components/DateRange/DateRange.js
+++ b/src/components/DateRange/DateRange.js
@@ -17,8 +17,7 @@ const END_DATE = 'End date'
 
 const Labels = ({ enabled, text }) => {
   const theme = useTheme()
-  const color =
-    text.indexOf(START_DATE) > -1 ? theme.surfaceContentSecondary : 'inherit'
+  const color = text.indexOf(START_DATE) > -1 ? theme.hint : 'inherit'
   const [start, end] = text.split('|')
   return (
     <div
@@ -38,7 +37,7 @@ const Labels = ({ enabled, text }) => {
           height: ${INPUT_HEIGHT_WITHOUT_BORDER}px;
           overflow: hidden;
           color: ${color};
-          ${textStyle('body3')}
+          ${textStyle('body2')}
         `}
       >
         <div css="text-align: center;">{start}</div>


### PR DESCRIPTION
Uses `theme.hint` as the colour, and adjusts its text size to be inline with other text inputs.

Previously:

<img width="560" alt="Screen Shot 2019-08-19 at 12 28 49 PM" src="https://user-images.githubusercontent.com/4166642/63258704-f2fe5c00-c27c-11e9-9966-c8e02211e543.png">


Now:

<img width="558" alt="Screen Shot 2019-08-19 at 12 25 46 PM" src="https://user-images.githubusercontent.com/4166642/63258657-cd715280-c27c-11e9-8017-e98cfad6f80a.png">
