### PR TITLE
Keydown fixes

### DIFF
--- a/src/components/Tabs/TabsFullWidth.js
+++ b/src/components/Tabs/TabsFullWidth.js
@@ -106,13 +106,18 @@ function TabsFullWidth({ items, selected, onChange }) {
             css={`
               display: flex;
               align-items: center;
-              padding: 0 ${2 * GU}px;
+              justify-content: center;
+              width: ${7 * GU}px;
+              height: 100%;
               color: ${theme.surfaceIcon};
-              transition: transform 150ms ease-in-out;
-              transform: rotate3d(0, 0, 1, ${opened ? 180 : 0}deg);
             `}
           >
-            <IconDown />
+            <IconDown
+              css={`
+                transition: transform 150ms ease-in-out;
+                transform: rotate3d(0, 0, 1, ${opened ? 180 : 0}deg);
+              `}
+            />
           </div>
         </ButtonBase>
         <Transition

--- a/src/components/Tabs/TabsFullWidth.js
+++ b/src/components/Tabs/TabsFullWidth.js
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { Transition, animated } from 'react-spring'
 import { GU, textStyle, springs } from '../../style'
-import { useOnBlur, useKeyDown } from '../../hooks'
+import { useOnBlur } from '../../hooks'
 import { IconDown } from '../../icons'
 import { useTheme } from '../../theme'
 import { useInside } from '../../utils'
 import { ButtonBase } from '../Button/ButtonBase'
 
-const ESC_CODE = 27
+const KEY_ESC = 27
 
 // TabsFullWidth is an internal component
 /* eslint-disable react/prop-types */
@@ -41,9 +41,23 @@ function TabsFullWidth({ items, selected, onChange }) {
     setOpened(false)
   }, [selectedItem])
 
-  useKeyDown(ESC_CODE, () => {
-    close()
-  })
+  useEffect(() => {
+    // only react to the escape key when the menu is opened
+    if (!opened) {
+      return
+    }
+
+    const onKeyDown = event => {
+      if (event.keyCode === KEY_ESC) {
+        close()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [opened, close])
 
   return (
     <div

--- a/src/components/Tabs/TabsFullWidth.js
+++ b/src/components/Tabs/TabsFullWidth.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { Transition, animated } from 'react-spring'
 import { GU, textStyle, springs } from '../../style'
 import { useOnBlur } from '../../hooks'
@@ -34,10 +34,13 @@ function TabsFullWidth({ items, selected, onChange }) {
 
   const change = useCallback(
     index => {
-      onChange(index)
-      close()
+      if (index !== selectedItem) {
+        onChange(index)
+        close()
+        focusButton()
+      }
     },
-    [onChange]
+    [onChange, close, focusButton]
   )
 
   const { handleBlur, ref } = useOnBlur(close)
@@ -50,14 +53,8 @@ function TabsFullWidth({ items, selected, onChange }) {
         focusButton()
       }
     },
-    [close]
+    [close, focusButton]
   )
-
-  // close when the selected item changes
-  useEffect(() => {
-    close()
-    focusButton()
-  }, [selectedItem])
 
   return (
     <div

--- a/src/hooks/useKeyDown.js
+++ b/src/hooks/useKeyDown.js
@@ -1,7 +1,7 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 export function useKeyDown(key, callback) {
-  const keys = Array.isArray(key) ? key : [key]
+  const keys = useMemo(() => (Array.isArray(key) ? key : [key]), [key])
 
   const handlekeyDown = useCallback(
     event => {


### PR DESCRIPTION
-  `TabsFullWidth`: only listen to keydown events when needed.
-  `useKeyDown()`: prevent the event callback to be recreated on every render.