### PR TITLE
Box: update padding behavior

### DIFF
--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -5,11 +5,23 @@ import { useTheme } from '../../theme/Theme'
 import { useLayout } from '../Layout/Layout'
 import { useInside } from '../../utils'
 
-function getPaddingValue(padding, insideSplitPrimary) {
-  if (typeof padding === 'boolean') {
-    return padding ? (insideSplitPrimary ? 5 : 2) * GU : 0
+// Padding values for the heading and the content.
+function getPaddingValues(padding, { insideSplitPrimary, fullWidth }) {
+  const defaultPadding = (fullWidth ? 2 : insideSplitPrimary ? 5 : 3) * GU
+
+  // Separate values for the header and content
+  if (Array.isArray(padding)) {
+    return padding
   }
-  return padding
+
+  // Default value if true, disable padding on the content otherwise
+  if (typeof padding === 'boolean') {
+    return [defaultPadding, padding ? defaultPadding : 0]
+  }
+
+  // The heading follows the content padding except when 0,
+  // in which case it will follow the default value.
+  return [padding === 0 ? defaultPadding : padding, padding]
 }
 
 function Box({ heading, children, padding, ...props }) {
@@ -18,7 +30,10 @@ function Box({ heading, children, padding, ...props }) {
   const { layoutName } = useLayout()
   const fullWidth = layoutName === 'small'
 
-  const paddingValue = getPaddingValue(padding, insideSplitPrimary)
+  const [headerPadding, contentPadding] = getPaddingValues(padding, {
+    insideSplitPrimary,
+    fullWidth,
+  })
 
   return (
     <div
@@ -46,12 +61,24 @@ function Box({ heading, children, padding, ...props }) {
             border-bottom: 1px solid ${theme.border};
           `}
         >
-          <HeaderContent heading={heading} padding={paddingValue} />
+          {typeof heading !== 'string' ? (
+            heading
+          ) : (
+            <h1
+              css={`
+                padding: 0 ${headerPadding}px;
+                ${textStyle('label2')};
+                color: ${theme.surfaceContentSecondary};
+              `}
+            >
+              {heading}
+            </h1>
+          )}
         </div>
       )}
       <div
         css={`
-          padding: ${paddingValue}px;
+          padding: ${contentPadding}px;
         `}
       >
         <div>{children}</div>
@@ -63,40 +90,15 @@ function Box({ heading, children, padding, ...props }) {
 Box.propTypes = {
   heading: PropTypes.node,
   children: PropTypes.node,
-  padding: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
+  padding: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.arrayOf(PropTypes.number),
+  ]),
 }
 
 Box.defaultProps = {
   padding: true,
-}
-
-function HeaderContent({ heading, padding }) {
-  const theme = useTheme()
-
-  if (!heading) {
-    return null
-  }
-
-  if (typeof heading !== 'string') {
-    return heading
-  }
-
-  return (
-    <h1
-      css={`
-        padding: 0 ${padding}px;
-        color: ${theme.surfaceContentSecondary};
-        ${textStyle('label2')};
-      `}
-    >
-      {heading}
-    </h1>
-  )
-}
-
-HeaderContent.propTypes = {
-  heading: PropTypes.node,
-  padding: PropTypes.number,
 }
 
 export { Box }

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -55,6 +55,10 @@ function Box({ heading, children, padding, ...props }) {
             height: ${4 * GU}px;
             padding: 0 ${defaultPadding}px;
             border-bottom: 1px solid ${theme.border};
+
+            // We pass the text style and color to the heading children, so
+            // that a node structure can inherit from it. Most components set
+            // their color and text style, but it is something to be aware of.
             color: ${theme.surfaceContentSecondary};
             ${textStyle('label2')};
           `}

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -1,54 +1,9 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { GU, RADIUS, textStyle } from '../../style'
 import { useTheme } from '../../theme/Theme'
 import { useLayout } from '../Layout/Layout'
-import { useInside } from '../../utils'
-
-function getHeadingPadding(padding, defaultPadding) {
-  // only follow the shared padding if not 0
-  if (typeof padding === 'number') {
-    return padding === 0 ? defaultPadding : padding
-  }
-
-  // always follow the heading padding if set independently
-  if (typeof padding === 'object' && typeof padding.heading === 'number') {
-    return padding.heading
-  }
-
-  // 0 if heading is set to false independently
-  if (typeof padding === 'object' && padding.heading === false) {
-    return 0
-  }
-
-  // default padding in all the other cases
-  return defaultPadding
-}
-
-function getContentPadding(padding, defaultPadding) {
-  // always follow the shared padding if set
-  if (typeof padding === 'number') {
-    return padding
-  }
-
-  // use the default padding if set to true, 0 otherwise
-  if (typeof padding === 'boolean') {
-    return padding ? defaultPadding : 0
-  }
-
-  // always follow the content padding if set independently
-  if (typeof padding === 'object' && typeof padding.content === 'number') {
-    return padding.content
-  }
-
-  // always 0 if content is set to false independently
-  if (typeof padding === 'object' && padding.content === false) {
-    return 0
-  }
-
-  // default padding in all the other cases
-  return defaultPadding
-}
+import { useInside, warnOnce } from '../../utils'
 
 function Box({ heading, children, padding, ...props }) {
   const theme = useTheme()
@@ -56,14 +11,24 @@ function Box({ heading, children, padding, ...props }) {
   const { layoutName } = useLayout()
   const fullWidth = layoutName === 'small'
 
-  const [headingPadding, contentPadding] = useMemo(() => {
-    const defaultPadding = (fullWidth ? 2 : insideSplitPrimary ? 5 : 3) * GU
+  const defaultPadding = (fullWidth ? 2 : insideSplitPrimary ? 5 : 3) * GU
 
-    return [
-      getHeadingPadding(padding, defaultPadding),
-      getContentPadding(padding, defaultPadding),
-    ]
-  }, [fullWidth, insideSplitPrimary, padding])
+  if (padding === true) {
+    warnOnce(
+      'Box:padding:true',
+      'Box: setting true on the padding prop is deprecated. Omit it, or set it to undefined instead.'
+    )
+    padding = defaultPadding
+  }
+  if (padding === false) {
+    warnOnce(
+      'Box:padding:false',
+      'Box: setting false on the padding prop is deprecated. Use 0.'
+    )
+    padding = 0
+  }
+
+  const contentPadding = padding === undefined ? defaultPadding : padding
 
   return (
     <div
@@ -96,7 +61,7 @@ function Box({ heading, children, padding, ...props }) {
           ) : (
             <h1
               css={`
-                padding: 0 ${headingPadding}px;
+                padding: 0 ${defaultPadding}px;
                 ${textStyle('label2')};
                 color: ${theme.surfaceContentSecondary};
               `}
@@ -121,17 +86,11 @@ Box.propTypes = {
   heading: PropTypes.node,
   children: PropTypes.node,
   padding: PropTypes.oneOfType([
-    PropTypes.bool,
     PropTypes.number,
-    PropTypes.shape({
-      heading: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
-      content: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
-    }),
-  ]),
-}
 
-Box.defaultProps = {
-  padding: true,
+    // deprecated
+    PropTypes.bool,
+  ]),
 }
 
 export { Box }

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -48,28 +48,19 @@ function Box({ heading, children, padding, ...props }) {
       {...props}
     >
       {heading && (
-        <div
+        <h1
           css={`
             display: flex;
             align-items: center;
             height: ${4 * GU}px;
+            padding: 0 ${defaultPadding}px;
             border-bottom: 1px solid ${theme.border};
+            color: ${theme.surfaceContentSecondary};
+            ${textStyle('label2')};
           `}
         >
-          {typeof heading !== 'string' ? (
-            heading
-          ) : (
-            <h1
-              css={`
-                padding: 0 ${defaultPadding}px;
-                ${textStyle('label2')};
-                color: ${theme.surfaceContentSecondary};
-              `}
-            >
-              {heading}
-            </h1>
-          )}
-        </div>
+          {heading}
+        </h1>
       )}
       <div
         css={`


### PR DESCRIPTION
As seen with @dizzypaty, we’ll keep a padding of 2gu all around in full width mode: any extra spacing can be added, but the line height of our text styles is enough in most cases to make it like the design screens.

- ~It is now possible to provide the header and content padding separately, by using an array.~
- Fix the default values (always 2gu in full width).
- ~When padding is 0 or false, the header stop following the content padding (it is still possible to do this by setting it independently using the array).~
- The header stop following the content padding.
- Coding style: remove the internal HeaderContent component.

