### PR TITLE
BackButton: adjust padding based on layout, factor in icon padding

### DIFF
--- a/src/components/BackButton/BackButton.js
+++ b/src/components/BackButton/BackButton.js
@@ -5,11 +5,16 @@ import { useTheme } from '../../theme'
 import { useInside } from '../../utils'
 import { Bar } from '../Bar/Bar'
 import ButtonBase from '../ButtonBase/ButtonBase'
+import { useLayout } from '../Layout/Layout'
 import { IconArrowLeft } from '../../icons'
 
 function BackButton({ label, ...props }) {
   const theme = useTheme()
   const [insideBarPrimary] = useInside('Bar:primary')
+
+  const { layoutName } = useLayout()
+  const compact = layoutName === 'small'
+  const horizontalPadding = (compact ? 2 : 3) * GU
 
   return (
     <ButtonBase
@@ -21,7 +26,8 @@ function BackButton({ label, ...props }) {
         border-radius: ${RADIUS}px 0 0 ${RADIUS}px;
         height: 100%;
         margin-left: ${insideBarPrimary ? -Bar.PADDING : 0}px;
-        padding: 0 ${3 * GU}px;
+        /* Adjust for icon's padding on the left */
+        padding: 0 ${horizontalPadding}px 0 ${horizontalPadding - 4}px;
         border-right: 1px solid ${theme.border};
         color: ${theme.surfaceContent};
         background: ${theme.surfaceInteractive};


### PR DESCRIPTION
The current alignments on larger and smaller screens:

Larger:
<img width="150" alt="Screen Shot 2019-08-29 at 3 57 17 PM" src="https://user-images.githubusercontent.com/4166642/63946763-fa401980-ca75-11e9-805d-d73c8c69d012.png">

Smaller:
<img width="100" alt="Screen Shot 2019-08-29 at 3 57 37 PM" src="https://user-images.githubusercontent.com/4166642/63946767-fca27380-ca75-11e9-82bc-2d72951340ac.png">
