### PR TITLE
FocusVisible: performance fix

### DIFF
--- a/src/components/FocusVisible/FocusVisible.js
+++ b/src/components/FocusVisible/FocusVisible.js
@@ -58,7 +58,9 @@ class FocusVisible extends React.Component {
     this._timer = setTimeout(() => {
       this._pointerActive = false
     }, 0)
-    this.setState({ focusVisible: false })
+    if (this.state.focusVisible) {
+      this.setState({ focusVisible: false })
+    }
   }
   // This is passed to `children()`, and called from the outside.
   handleFocus = () => {


### PR DESCRIPTION
I didn’t realize before how slow `this.setState` can be, even without changing any value. The next step would be to share the same context between all the `FocusVisible` components, so the event is only triggered once.