### PR TITLE
Fix some component warnings

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -149,19 +149,24 @@ function Button({
 }) {
   // backward compatibility and deprecated props
   if (iconOnly) {
-    warnOnce('Button: "iconOnly" is deprecated, please use "display".')
+    warnOnce(
+      'Button:iconOnly',
+      'Button: "iconOnly" is deprecated, please use "display".'
+    )
     display = 'icon'
   }
   if (mode === 'outline' || mode === 'secondary') {
-    warnOnce(`Button: the mode "${mode}" is deprecated, please use "normal".`)
+    warnOnce(
+      'Button:mode',
+      `Button: the mode "${mode}" is deprecated, please use "normal".`
+    )
     mode = 'normal'
   }
-  if (size === 'normal') {
-    warnOnce(`Button: the size "normal" is deprecated, please use "medium".`)
-    size = 'medium'
-  }
-  if (size === 'large') {
-    warnOnce(`Button: the size "large" is deprecated, please use "medium".`)
+  if (size === 'normal' || size === 'large') {
+    warnOnce(
+      'Button:size',
+      `Button: the size "${size}" is deprecated, please use "medium".`
+    )
     size = 'medium'
   }
 

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -5,7 +5,7 @@ import { Transition, animated } from 'react-spring'
 import { useRoot } from '../../providers'
 import { springs, RADIUS } from '../../style'
 import { useTheme } from '../../theme'
-import { noop, stylingProps, KEY_ESC } from '../../utils'
+import { noop, stylingProps, warn, KEY_ESC } from '../../utils'
 import RootPortal from '../RootPortal/RootPortal'
 
 class PopoverBase extends React.Component {
@@ -140,6 +140,17 @@ class PopoverBase extends React.Component {
         this._cardElement.current.contains(focusedElement)) ||
       (closeOnOpenerFocus && opener && opener.contains(focusedElement))
     ) {
+      if (
+        closeOnOpenerFocus &&
+        (opener.tagName === 'BUTTON' || opener.tagName === 'INPUT')
+      ) {
+        warn(
+          'Popover: using "closeOnOpenerFocus" with a <button> or <input> may lead to bugs due ' +
+            'to cross-environment focus event handling. ' +
+            'See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus ' +
+            'for more information.'
+        )
+      }
       return
     }
 


### PR DESCRIPTION
- Button: `warnOnce()` was used incorrectly
- Popover: try to warn if the `opener` was a `<button>` or `<input>`, and `closeOnOpenerFocus` is set

The Popover's a bit of a PITA. On macOS, both Firefox and Safari don't focus buttons or inputs on click, hence causing `focusevent.relatedTarget` to always be `null`. Users should only be using `closeOnOpenerFocus` if they expect the opener to be focused, so this adds a warning to let users know they should consider using a different focusable element instead.

Note that this check is **not** full-proof, since it's a PITA for us to know if the passed in element is actually focusable (we'd need to implement a tag whitelist, check for `tabIndex`, etc. which probably isn't worth it now).