### PR TITLE
Design polish dropdown

### DIFF
--- a/devbox/apps/DropDown.js
+++ b/devbox/apps/DropDown.js
@@ -14,14 +14,7 @@ const items = [
       justifyContent: 'space-between',
     }}
   >
-    <span
-      css={`
-        /* Adjust for no descenders (due to textstyle: uppercase) */
-        padding-top: 4px;
-      `}
-    >
-      Test
-    </span>
+    <span>Test</span>
     <IdentityBadge entity="0xc41e4c10b37d3397a99d4a90e7d85508a69a5c4c" />
   </span>,
 ]

--- a/devbox/apps/DropDown.js
+++ b/devbox/apps/DropDown.js
@@ -14,7 +14,14 @@ const items = [
       justifyContent: 'space-between',
     }}
   >
-    <span>Test</span>
+    <span
+      css={`
+        /* Adjust for no descenders (due to textstyle: uppercase) */
+        padding-top: 4px;
+      `}
+    >
+      Test
+    </span>
     <IdentityBadge entity="0xc41e4c10b37d3397a99d4a90e7d85508a69a5c4c" />
   </span>,
 ]

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -192,7 +192,7 @@ const DropDown = React.memo(function DropDown({
           color: ${disabled ? theme.disabledContent : theme.surfaceContent};
           border: ${disabled ? 0 : 1}px solid
             ${closedWithChanges ? theme.selected : theme.border};
-          ${textStyle('label2')};
+          ${textStyle('body2')};
           ${disabled
             ? 'font-weight: 600;'
             : `

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -213,6 +213,8 @@ const DropDown = React.memo(function DropDown({
             position: absolute;
             top: -100vh;
             left: -100vw;
+            opacity: 0;
+            visibility: hidden;
           `}
         >
           <PopoverContent

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -120,8 +120,10 @@ const DropDown = React.memo(function DropDown({
     return -1
   }, [active, selected])
 
+  const [getContentWidth, setGetContentWidth] = useState(true)
   const { refCallback: popoverRefCallback } = useButtonRef(el => {
     setPlaceholderMinWidth(el.clientWidth)
+    setGetContentWidth(false)
   })
   const [widthNoPx = MIN_WIDTH] = (width || '').split('px')
   const [placeholderMinWidth, setPlaceholderMinWidth] = useState(
@@ -142,6 +144,10 @@ const DropDown = React.memo(function DropDown({
     }
     setButtonWidth(buttonRef.current.clientWidth)
   }, [buttonRef, vw])
+
+  useEffect(() => {
+    setGetContentWidth(true)
+  }, [vw])
 
   const {
     handleItemSelect,
@@ -201,54 +207,91 @@ const DropDown = React.memo(function DropDown({
           `}
         />
       </ButtonBase>
-      <Popover onClose={close} opener={buttonRef.current} visible={opened}>
+      {getContentWidth && (
         <div
           css={`
-            min-width: ${buttonWidth}px;
-            color: ${theme.surfaceContentSecondary};
+            position: absolute;
+            top: -100vh;
+            left: -100vw;
           `}
-          ref={popoverRefCallback}
         >
-          {header && (
-            <div
-              css={`
-                padding: ${1.5 * GU}px ${2 * GU}px ${1.25 * GU}px;
-                ${textStyle('label2')};
-                ${unselectable};
-              `}
-            >
-              {header}
-            </div>
-          )}
-          <ul
-            css={`
-              margin: 0;
-              list-style: none;
-              width: 100%;
-            `}
-          >
-            <Inside name="DropDown:menu">
-              {items.map((item, index) => {
-                return (
-                  <Item
-                    key={index}
-                    index={index}
-                    onSelect={handleItemSelect}
-                    theme={theme}
-                    item={item}
-                    header={header}
-                    length={items.length}
-                    selected={selectedIndex}
-                  />
-                )
-              })}
-            </Inside>
-          </ul>
+          <PopoverContent
+            refCallback={popoverRefCallback}
+            buttonWidth={buttonWidth}
+            header={header}
+            items={items}
+            handleItemSelect={handleItemSelect}
+            selectedIndex={selectedIndex}
+          />
         </div>
+      )}
+      <Popover onClose={close} opener={buttonRef.current} visible={opened}>
+        <PopoverContent
+          buttonWidth={buttonWidth}
+          header={header}
+          items={items}
+          handleItemSelect={handleItemSelect}
+          selectedIndex={selectedIndex}
+        />
       </Popover>
     </Inside>
   )
 })
+
+function PopoverContent({
+  refCallback = () => null,
+  buttonWidth,
+  header,
+  items,
+  handleItemSelect,
+  selectedIndex,
+}) {
+  const theme = useTheme()
+  return (
+    <div
+      css={`
+        min-width: ${buttonWidth}px;
+        color: ${theme.surfaceContentSecondary};
+      `}
+    >
+      {header && (
+        <div
+          css={`
+            padding: ${1.5 * GU}px ${2 * GU}px ${1.25 * GU}px;
+            ${textStyle('label2')};
+            ${unselectable};
+          `}
+        >
+          {header}
+        </div>
+      )}
+      <ul
+        css={`
+          margin: 0;
+          list-style: none;
+          width: 100%;
+        `}
+      >
+        <Inside name="DropDown:menu">
+          {items.map((item, index) => {
+            return (
+              <Item
+                key={index}
+                index={index}
+                onSelect={handleItemSelect}
+                theme={theme}
+                item={item}
+                header={header}
+                length={items.length}
+                selected={selectedIndex}
+              />
+            )
+          })}
+        </Inside>
+      </ul>
+    </div>
+  )
+}
 
 DropDown.propTypes = {
   disabled: PropTypes.bool,

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -121,10 +121,13 @@ const DropDown = React.memo(function DropDown({
   }, [active, selected])
 
   const [getContentWidth, setGetContentWidth] = useState(true)
-  const { refCallback: popoverRefCallback } = useButtonRef(el => {
+  const popoverRefCallback = useCallback(el => {
+    if (!el) {
+      return
+    }
     setPlaceholderMinWidth(el.clientWidth)
     setGetContentWidth(false)
-  })
+  }, [])
   const [widthNoPx = MIN_WIDTH] = (width || '').split('px')
   const [placeholderMinWidth, setPlaceholderMinWidth] = useState(
     Math.min(widthNoPx, MIN_WIDTH)

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -274,6 +274,7 @@ const PopoverContent = React.memo(function PopoverContent({
   const theme = useTheme()
   return (
     <div
+      ref={refCallback}
       css={`
         min-width: ${buttonWidth}px;
         color: ${theme.surfaceContentSecondary};

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -220,8 +220,6 @@ const DropDown = React.memo(function DropDown({
             buttonWidth={buttonWidth}
             header={header}
             items={items}
-            handleItemSelect={handleItemSelect}
-            selectedIndex={selectedIndex}
           />
         </div>
       )}
@@ -238,8 +236,30 @@ const DropDown = React.memo(function DropDown({
   )
 })
 
-function PopoverContent({
-  refCallback = () => null,
+DropDown.propTypes = {
+  disabled: PropTypes.bool,
+  header: PropTypes.node,
+  items: PropTypes.arrayOf(PropTypes.node).isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.node,
+  renderLabel: PropTypes.func,
+  selected: PropTypes.number,
+  wide: PropTypes.bool,
+  width: PropTypes.string,
+
+  // deprecated
+  active: PropTypes.number,
+  label: PropTypes.string,
+}
+
+DropDown.defaultProps = {
+  placeholder: 'Select an item',
+  renderLabel: ({ selectedLabel }) => selectedLabel,
+  wide: false,
+}
+
+const PopoverContent = React.memo(function PopoverContent({
+  refCallback,
   buttonWidth,
   header,
   items,
@@ -291,28 +311,21 @@ function PopoverContent({
       </ul>
     </div>
   )
+})
+
+PopoverContent.propTypes = {
+  refCallback: PropTypes.func.isRequired,
+  buttonWidth: PropTypes.number.isRequired,
+  header: PropTypes.node.isRequired,
+  items: PropTypes.array.isRequired,
+  handleItemSelect: PropTypes.func.isRequired,
+  selectedIndex: PropTypes.number.isRequired,
 }
 
-DropDown.propTypes = {
-  disabled: PropTypes.bool,
-  header: PropTypes.node,
-  items: PropTypes.arrayOf(PropTypes.node).isRequired,
-  onChange: PropTypes.func.isRequired,
-  placeholder: PropTypes.node,
-  renderLabel: PropTypes.func,
-  selected: PropTypes.number,
-  wide: PropTypes.bool,
-  width: PropTypes.string,
-
-  // deprecated
-  active: PropTypes.number,
-  label: PropTypes.string,
-}
-
-DropDown.defaultProps = {
-  placeholder: 'Select an item',
-  renderLabel: ({ selectedLabel }) => selectedLabel,
-  wide: false,
+PopoverContent.defaultProps = {
+  refCallback: () => null,
+  handleItemSelect: () => null,
+  selectedIndex: -1,
 }
 
 const Item = React.memo(function Item({

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -125,7 +125,8 @@ const DropDown = React.memo(function DropDown({
     if (!el) {
       return
     }
-    setPlaceholderMinWidth(el.clientWidth)
+    // Add 4 GU to accomodate for caret spacing
+    setPlaceholderMinWidth(el.clientWidth + 4 * GU)
     setGetContentWidth(false)
   }, [])
   const [widthNoPx = MIN_WIDTH] = (width || '').split('px')

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -109,6 +109,40 @@ const DropDown = React.memo(function DropDown({
   }
 
   const theme = useTheme()
+  const { width: vw } = useViewport()
+
+  const [widthNoPx = MIN_WIDTH] = (width || '').split('px')
+  const [placeholderMinWidth, setPlaceholderMinWidth] = useState(
+    Math.min(widthNoPx, MIN_WIDTH)
+  )
+  const [buttonWidth, setButtonWidth] = useState(0)
+  const [getContentWidth, setGetContentWidth] = useState(true)
+
+  // Adjust the button width if the item widths are larger than declared width
+  const popoverRefCallback = useCallback(el => {
+    if (!el) {
+      return
+    }
+    // Add 4 GU to accomodate for caret spacing
+    setPlaceholderMinWidth(el.clientWidth + 4 * GU)
+    setGetContentWidth(false)
+  }, [])
+  // Re-adjust if the width or items ever change
+  useEffect(() => {
+    setGetContentWidth(true)
+  }, [vw, items])
+
+  // Update the button width every time the reference updates
+  const { refCallback, buttonRef } = useButtonRef(el => {
+    setButtonWidth(el.clientWidth)
+  })
+  // And every time the viewport resizes
+  useEffect(() => {
+    if (!buttonRef.current) {
+      return
+    }
+    setButtonWidth(buttonRef.current.clientWidth)
+  }, [buttonRef, vw])
 
   const selectedIndex = useMemo(() => {
     if (selected !== undefined) {
@@ -119,39 +153,6 @@ const DropDown = React.memo(function DropDown({
     }
     return -1
   }, [active, selected])
-
-  const [getContentWidth, setGetContentWidth] = useState(true)
-  const popoverRefCallback = useCallback(el => {
-    if (!el) {
-      return
-    }
-    // Add 4 GU to accomodate for caret spacing
-    setPlaceholderMinWidth(el.clientWidth + 4 * GU)
-    setGetContentWidth(false)
-  }, [])
-  const [widthNoPx = MIN_WIDTH] = (width || '').split('px')
-  const [placeholderMinWidth, setPlaceholderMinWidth] = useState(
-    Math.min(widthNoPx, MIN_WIDTH)
-  )
-  const [buttonWidth, setButtonWidth] = useState(0)
-
-  const { refCallback, buttonRef } = useButtonRef(el => {
-    // Update the button width every time the reference updates
-    setButtonWidth(el.clientWidth)
-  })
-
-  // And every time the viewport resizes
-  const { width: vw } = useViewport()
-  useEffect(() => {
-    if (!buttonRef.current) {
-      return
-    }
-    setButtonWidth(buttonRef.current.clientWidth)
-  }, [buttonRef, vw])
-
-  useEffect(() => {
-    setGetContentWidth(true)
-  }, [vw, items])
 
   const {
     handleItemSelect,

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -120,6 +120,9 @@ const DropDown = React.memo(function DropDown({
     return -1
   }, [active, selected])
 
+  const { refCallback: popoverRefCallback } = useButtonRef(el => {
+    setPlaceholderMinWidth(el.clientWidth)
+  })
   const [widthNoPx = MIN_WIDTH] = (width || '').split('px')
   const [placeholderMinWidth, setPlaceholderMinWidth] = useState(
     Math.min(widthNoPx, MIN_WIDTH)
@@ -204,6 +207,7 @@ const DropDown = React.memo(function DropDown({
             min-width: ${buttonWidth}px;
             color: ${theme.surfaceContentSecondary};
           `}
+          ref={popoverRefCallback}
         >
           {header && (
             <div

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -8,6 +8,8 @@ import { useViewport } from '../../providers/Viewport/Viewport'
 import ButtonBase from '../ButtonBase/ButtonBase'
 import Popover from '../Popover/Popover'
 
+const MIN_WIDTH = 128
+
 function useDropDown({
   buttonRef,
   items,
@@ -118,6 +120,10 @@ const DropDown = React.memo(function DropDown({
     return -1
   }, [active, selected])
 
+  const [widthNoPx = MIN_WIDTH] = (width || '').split('px')
+  const [placeholderMinWidth, setPlaceholderMinWidth] = useState(
+    Math.min(widthNoPx, MIN_WIDTH)
+  )
   const [buttonWidth, setButtonWidth] = useState(0)
 
   const { refCallback, buttonRef } = useButtonRef(el => {
@@ -128,9 +134,10 @@ const DropDown = React.memo(function DropDown({
   // And every time the viewport resizes
   const { width: vw } = useViewport()
   useEffect(() => {
-    if (buttonRef.current) {
-      setButtonWidth(buttonRef.current.clientWidth)
+    if (!buttonRef.current) {
+      return
     }
+    setButtonWidth(buttonRef.current.clientWidth)
   }, [buttonRef, vw])
 
   const {
@@ -163,13 +170,15 @@ const DropDown = React.memo(function DropDown({
           justify-content: space-between;
           align-items: center;
           height: ${5 * GU}px;
-          padding: 0 ${2 * GU}px;
+          padding-left: ${2 * GU}px;
+          padding-right: ${1.5 * GU}px;
           width: ${width || (wide ? '100%' : 'auto')};
+          min-width: ${placeholderMinWidth}px;
           background: ${disabled ? theme.disabled : theme.surface};
           color: ${disabled ? theme.disabledContent : theme.surfaceContent};
           border: ${disabled ? 0 : 1}px solid
             ${closedWithChanges ? theme.selected : theme.border};
-          ${textStyle('body2')};
+          ${textStyle('label2')};
           ${disabled
             ? 'font-weight: 600;'
             : `
@@ -184,7 +193,7 @@ const DropDown = React.memo(function DropDown({
         <IconDown
           size="tiny"
           css={`
-            margin-left: ${1 * GU}px;
+            margin-left: ${1.5 * GU}px;
             color: ${closedWithChanges && !disabled ? theme.accent : 'inherit'};
           `}
         />

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -147,7 +147,7 @@ const DropDown = React.memo(function DropDown({
 
   useEffect(() => {
     setGetContentWidth(true)
-  }, [vw])
+  }, [vw, items])
 
   const {
     handleItemSelect,


### PR DESCRIPTION
The second commit (https://github.com/aragon/aragon-ui/commit/688ba3940d7fdc52192613e17261ac07233d7057) is a first attempt to get the `Popover`'s width and use that as the `min-width` for the container, but it only works after the first time the `Popover` appears.

Update: as discussed with @bpierre , followed the approach of having an invisible (out of viewport) content to get the width from.