### PR TITLE
Button: fix the shadow of the pressed state

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -253,7 +253,7 @@ function Button({
         transition-timing-function: ease-in-out;
         &:active {
           transform: ${disabled ? 'none' : 'translateY(1px)'};
-          box-shadow: ${disabled ? 'none' : '0px 1px 3px rgba(0, 0, 0, 0.125)'};
+          box-shadow: ${disabled ? 'none' : '0px 1px 3px rgba(0, 0, 0, 0.08)'};
         }
       `}
     >


### PR DESCRIPTION
The Button shadow has been [changed](https://github.com/aragon/aragon-ui/commit/62b7a0fa0c7d351264f37829b91eb396340e9a65) at some point, but without adapting its pressed state. This change fixes that.