### PR TITLE
Dropdown + IdentityBadge fixes

### DIFF
--- a/devbox/apps/DropDown.js
+++ b/devbox/apps/DropDown.js
@@ -1,8 +1,23 @@
 import React from 'react'
 import styled from 'styled-components'
-import { DropDown, unselectable } from '@aragon/ui'
+import { IdentityBadge, DropDown, unselectable } from '@aragon/ui'
 
-const items = ['Strawberry', 'Banana', 'Apple', 'Cherry']
+const items = [
+  'Strawberry',
+  'Banana',
+  'Apple',
+  'Cherry',
+  <span
+    style={{
+      display: 'flex',
+      width: '100%',
+      justifyContent: 'space-between',
+    }}
+  >
+    <span>Test</span>
+    <IdentityBadge entity="0xc41e4c10b37d3397a99d4a90e7d85508a69a5c4c" />
+  </span>,
+]
 
 class App extends React.Component {
   state = { active: -1 }

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { warnOnce, unselectable } from '../../utils'
+import { warnOnce, unselectable, Inside } from '../../utils'
 import { GU, RADIUS, textStyle } from '../../style'
 import { useTheme } from '../../theme'
 import { IconDown } from '../../icons'
@@ -151,7 +151,7 @@ const DropDown = React.memo(function DropDown({
   const Label = renderLabel
 
   return (
-    <React.Fragment>
+    <Inside name="DropDown">
       <ButtonBase
         ref={refCallback}
         disabled={disabled}
@@ -219,24 +219,26 @@ const DropDown = React.memo(function DropDown({
               width: 100%;
             `}
           >
-            {items.map((item, index) => {
-              return (
-                <Item
-                  key={index}
-                  index={index}
-                  onSelect={handleItemSelect}
-                  theme={theme}
-                  item={item}
-                  header={header}
-                  length={items.length}
-                  selected={selectedIndex}
-                />
-              )
-            })}
+            <Inside name="DropDown:menu">
+              {items.map((item, index) => {
+                return (
+                  <Item
+                    key={index}
+                    index={index}
+                    onSelect={handleItemSelect}
+                    theme={theme}
+                    item={item}
+                    header={header}
+                    length={items.length}
+                    selected={selectedIndex}
+                  />
+                )
+              })}
+            </Inside>
           </ul>
         </div>
       </Popover>
-    </React.Fragment>
+    </Inside>
   )
 })
 

--- a/src/components/DropDown/DropDown.js
+++ b/src/components/DropDown/DropDown.js
@@ -189,12 +189,7 @@ const DropDown = React.memo(function DropDown({
           `}
         />
       </ButtonBase>
-      <Popover
-        closeOnOpenerFocus
-        onClose={close}
-        opener={buttonRef.current}
-        visible={opened}
-      >
+      <Popover onClose={close} opener={buttonRef.current} visible={opened}>
         <div
           css={`
             min-width: ${buttonWidth}px;

--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 import { GU, RADIUS, textStyle } from '../../style'
 import { useTheme } from '../../theme'
-import { isAddress, shortenAddress, warnOnce } from '../../utils'
+import { useInside, isAddress, shortenAddress, warnOnce } from '../../utils'
 import ButtonBase from '../ButtonBase/ButtonBase'
 import EthIdenticon from '../EthIdenticon/EthIdenticon'
 import IdentityBadgePopover from './IdentityBadgePopover'
@@ -34,6 +34,7 @@ const IdentityBadge = React.memo(function IdentityBadge({
 
   const theme = useTheme()
   const elementRef = useRef(null)
+  const [insideDropDownMenu] = useInside('DropDown')
 
   const [opened, setOpened] = useState(false)
   const handleClose = useCallback(() => {
@@ -47,13 +48,15 @@ const IdentityBadge = React.memo(function IdentityBadge({
   const label =
     customLabel || (address && shorten ? shortenAddress(address) : entity)
 
+  const localBadgeOnly = insideDropDownMenu || badgeOnly
+
   return (
     <React.Fragment>
       <ButtonBase
         ref={elementRef}
         title={address}
-        disabled={badgeOnly}
-        onClick={address && !badgeOnly ? handleOpen : undefined}
+        disabled={localBadgeOnly}
+        onClick={address && !localBadgeOnly ? handleOpen : undefined}
         focusRingRadius={RADIUS}
         css={`
           display: inline-flex;
@@ -112,7 +115,7 @@ const IdentityBadge = React.memo(function IdentityBadge({
           </span>
         </div>
       </ButtonBase>
-      {address && !badgeOnly && (
+      {address && !localBadgeOnly && (
         <IdentityBadgePopover
           address={address}
           visible={opened}

--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -56,6 +56,7 @@ const IdentityBadge = React.memo(function IdentityBadge({
         ref={elementRef}
         title={address}
         disabled={localBadgeOnly}
+        element={localBadgeOnly ? 'a' : 'button'}
         onClick={address && !localBadgeOnly ? handleOpen : undefined}
         focusRingRadius={RADIUS}
         css={`


### PR DESCRIPTION
-  DropDown: declare `Inside` slots.
- DropDown: stop using closeOnOpenerFocus (removes the warning).
-  IdentityBadge: set `badgeOnly` to `true` when inside of a `DropDown`. 
-  IdentityBadge: use `element="a"` when `badgeOnly=true` (fixes https://github.com/aragon/aragon-ui/issues/448).