### PR TITLE
Integrate Help into Field

### DIFF
--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { useTheme } from '../../theme'
 import { textStyle, GU } from '../../style'
-import { unselectable } from '../../utils'
+import { unselectable, Inside } from '../../utils'
+
+let fieldId = 1
 
 function Field({ children, label, required, ...props }) {
   const theme = useTheme()
@@ -13,45 +15,60 @@ function Field({ children, label, required, ...props }) {
       ({ props }) => props && props.required
     )
 
+  const id = useMemo(
+    () => (typeof children === 'function' ? `Field_${fieldId++}` : null),
+    [children]
+  )
+
+  const labelProps = id === null ? {} : { htmlFor: id }
+
   return (
-    <div
-      css={`
-        margin-bottom: ${3 * GU}px;
-      `}
-      {...props}
-    >
-      <label>
-        <div
-          css={`
-            display: flex;
-            margin-bottom: ${0.5 * GU}px;
-            color: ${theme.surfaceContentSecondary};
-            ${unselectable()};
-            ${textStyle('label2')};
-            line-height: ${2 * GU}px;
-          `}
-        >
-          {label}
-          {isRequired && (
-            <span
-              css={`
-                color: ${theme.accent};
-              `}
-              title="Required"
-            >
-              {'\u00a0*'}
-            </span>
-          )}
-        </div>
-        {children}
-      </label>
-    </div>
+    <Inside name="Field">
+      <div
+        css={`
+          margin-bottom: ${3 * GU}px;
+        `}
+        {...props}
+      >
+        <label {...labelProps}>
+          <div
+            css={`
+              display: flex;
+              align-items: center;
+              height: ${2 * GU}px;
+              margin-bottom: ${0.5 * GU}px;
+              color: ${theme.surfaceContentSecondary};
+              white-space: nowrap;
+              ${textStyle('label2')};
+              ${unselectable()};
+            `}
+          >
+            <Inside name="Field:label">
+              {label}
+              {isRequired && (
+                <span
+                  css={`
+                    color: ${theme.accent};
+                  `}
+                  title="Required"
+                >
+                  {'\u00a0*'}
+                </span>
+              )}
+            </Inside>
+          </div>
+          <Inside name="Field:content">
+            {id === null ? children : children({ id })}
+          </Inside>
+        </label>
+      </div>
+    </Inside>
   )
 }
 
 Field.propTypes = {
-  children: PropTypes.node,
-  label: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+  label: PropTypes.node,
   required: PropTypes.bool,
 }
 

--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -4,6 +4,9 @@ import { useTheme } from '../../theme'
 import { textStyle, GU } from '../../style'
 import { unselectable, Inside } from '../../utils'
 
+// This variable is used as a simple mechanism to generate unique IDs, that can
+// be used to link the <label> to a specific form element by using a render
+// prop. See `children` in the Field documentation for more details.
 let fieldId = 1
 
 function Field({ children, label, required, ...props }) {

--- a/src/components/Field/Field.js
+++ b/src/components/Field/Field.js
@@ -61,7 +61,7 @@ function Field({ children, label, required, ...props }) {
             </Inside>
           </div>
           <Inside name="Field:content">
-            {id === null ? children : children({ id })}
+            {typeof children === 'function' ? children({ id }) : children}
           </Inside>
         </label>
       </div>

--- a/src/components/Field/README.md
+++ b/src/components/Field/README.md
@@ -19,7 +19,7 @@ const App = () => (
 ### `label`
 
 | Type     | Default value |
-| ---------| ------------- |
+| -------- | ------------- |
 | `String` | None          |
 
 Set a label for your Field.
@@ -27,19 +27,39 @@ Set a label for your Field.
 #### Example:
 
 ```jsx
-const App = () => (
-  <Field label="Billing Address">
-    {/* Field Input(s) */}
-  </Field>
-)
+const App = () => <Field label="Billing Address">{/* Field Input(s) */}</Field>
 ```
 
 ### `required`
 
 | Type      | Default value |
-| ----------| ------------- |
+| --------- | ------------- |
 | `Boolean` | None          |
 
 Marks the field as a required field. If not provided, `Field` will attempt to
 detect if the field is required by checking if any of its children contain a
 truthy `required` prop.
+
+### `children`
+
+| Type                       | Default value |
+| -------------------------- | ------------- |
+| `React node` or `Function` | None          |
+
+The field content, usually a form element like `TextInput`.
+
+When a function is passed, it will take an object as parameter containing an
+`id` key, whose value is set to a unique id that can be passed to the desired form element.
+
+Example:
+
+```jsx
+<Field label="Phone number">
+  {({ id }) => (
+    <p>
+      <TextInput placeholder="Prefix" value="+44" />
+      <TextInput placeholder="Number" value="" id={id} />
+    </p>
+  )}
+</Field>
+```

--- a/src/components/Help/Help.js
+++ b/src/components/Help/Help.js
@@ -14,6 +14,7 @@ function Help({ hint, children }) {
   const open = useCallback(() => setVisible(true), [])
   const close = useCallback(() => setVisible(false), [])
   const [insideBoxHeading] = useInside('Box:heading')
+  const [insideFieldLabel] = useInside('Field:label')
   return (
     <React.Fragment>
       <DiscButton
@@ -22,7 +23,8 @@ function Help({ hint, children }) {
         onClick={open}
         size={2 * GU}
         css={`
-          margin-left: ${insideBoxHeading ? 1 * GU : 0}px;
+          margin-top: ${insideFieldLabel ? -3 : 0}px;
+          margin-left: ${insideBoxHeading || insideFieldLabel ? 1 * GU : 0}px;
         `}
       >
         <IconQuestion size="tiny" />


### PR DESCRIPTION
- Allow children to be a render function that will receive a unique ID, being assigned to the htmlFor prop of the label element (allowing to target a specific element rather than the first one found).
- Declare Inside slots.
- Center using flexbox rather than a custom line-height.
- Add white-space: nowrap.
- Accept React nodes for the label, rather than strings only.

Note: the render prop is a first step that will also be useful for advanced uses, but a solution (to be thought / discussed) will be added later so that `Help` can be used without having to use this feature.