### PR TITLE
Modal: use display: flex to center modal

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -56,9 +56,9 @@ function Modal({
                   left: 0;
                   right: 0;
                   bottom: 0;
-                  display: grid;
+                  display: flex;
                   align-items: center;
-                  justify-items: center;
+                  justify-content: center;
                   overflow: auto;
                 `}
                 style={{


### PR DESCRIPTION
Safari doesn't seem to respect the alignment with `grid`, and this for all intents and purposes can use `flex` instead.

See, for example, the share label modal:

<img width="1119" alt="Screen Shot 2019-09-06 at 6 32 59 PM" src="https://user-images.githubusercontent.com/4166642/64444622-d95e7080-d0d4-11e9-96cc-8be5f6dcaf7e.png">
