### PR TITLE
AppBadge: avoid appAddress warning if badgeOnly is set

### DIFF
--- a/src/components/AppBadge/AppBadge.js
+++ b/src/components/AppBadge/AppBadge.js
@@ -28,7 +28,7 @@ const IdentityBadge = React.memo(function IdentityBadge({
   const handleOpen = useCallback(() => setOpened(true), [])
 
   const isValidAddress = isAddress(appAddress)
-  if (!isValidAddress) {
+  if (!badgeOnly && !isValidAddress) {
     warn(`AppBadge: provided invalid app address (${appAddress})`)
   }
 


### PR DESCRIPTION
The `appAddress` is only used in the AppBadge's popover, and this is disabled in `badgeOnly` mode.