### PR TITLE
Build: disable analyzing brotli file size

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,6 @@ export default {
       filesize({
         showMinifiedSize: true,
         showGzippedSize: true,
-        showBrotliSize: true,
       }),
     production && sizes(),
     production && visualizer(),


### PR DESCRIPTION
The `filesize` plugin seems to have started failing when trying to generate the brotli file size.