### PR TITLE
Modal: fix overflowing height and centering on Safari

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -56,8 +56,8 @@ function Modal({
                   left: 0;
                   right: 0;
                   bottom: 0;
-                  display: flex;
-                  align-items: center;
+                  display: grid;
+                  align-content: center;
                   justify-content: center;
                   overflow: auto;
                 `}


### PR DESCRIPTION
Essentially reverts https://github.com/aragon/aragon-ui/pull/582, but changes the `align-items` to `align-content` as a way of getting the centering to work on Safari.