### PR TITLE
Split: allow to invert (visually) the two slots

### DIFF
--- a/src/components/Split/Split.js
+++ b/src/components/Split/Split.js
@@ -4,9 +4,43 @@ import { useLayout } from '../Layout/Layout'
 import { GU } from '../../style'
 import { Inside } from '../../utils'
 
-function Split({ primary, secondary }) {
+function Split({ primary, secondary, invert }) {
   const { name: layout } = useLayout()
   const oneColumn = layout === 'small' || layout === 'medium'
+
+  const inverted =
+    (!oneColumn && invert === 'rows') || (oneColumn && invert === 'columns')
+
+  const primaryContent = (
+    <Inside name="Split:primary">
+      <div
+        css={`
+          flex-grow: 1;
+          margin-left: ${!oneColumn && inverted ? 2 * GU : 0}px;
+          padding-top: ${oneColumn && inverted ? 2 * GU : 0}px;
+        `}
+      >
+        {primary}
+      </div>
+    </Inside>
+  )
+
+  const secondaryContent = (
+    <Inside name="Split:secondary">
+      <div
+        css={`
+          flex-shrink: 0;
+          flex-grow: 0;
+          width: ${oneColumn ? '100%' : `${33 * GU}px`};
+          margin-left: ${!oneColumn && !inverted ? 2 * GU : 0}px;
+          padding-top: ${oneColumn && !inverted ? 2 * GU : 0}px;
+        `}
+      >
+        {secondary}
+      </div>
+    </Inside>
+  )
+
   return (
     <Inside name="Split">
       <div
@@ -16,30 +50,21 @@ function Split({ primary, secondary }) {
           width: 100%;
         `}
       >
-        <Inside name="Split:primary">
-          <div css="flex-grow: 1">{primary}</div>
-        </Inside>
-        <Inside name="Split:secondary">
-          <div
-            css={`
-              flex-shrink: 0;
-              flex-grow: 0;
-              width: ${oneColumn ? '100%' : `${33 * GU}px`};
-              margin-left: ${oneColumn ? 0 : 2 * GU}px;
-              padding-top: ${oneColumn ? 2 * GU : 0}px;
-            `}
-          >
-            {secondary}
-          </div>
-        </Inside>
+        {inverted ? secondaryContent : primaryContent}
+        {inverted ? primaryContent : secondaryContent}
       </div>
     </Inside>
   )
 }
 
 Split.propTypes = {
+  invert: PropTypes.oneOf(['none', 'rows', 'columns']),
   primary: PropTypes.node,
   secondary: PropTypes.node,
+}
+
+Split.defaultProps = {
+  invert: 'none',
 }
 
 export { Split }

--- a/src/components/Split/Split.js
+++ b/src/components/Split/Split.js
@@ -9,7 +9,8 @@ function Split({ primary, secondary, invert }) {
   const oneColumn = layout === 'small' || layout === 'medium'
 
   const inverted =
-    (!oneColumn && invert === 'rows') || (oneColumn && invert === 'columns')
+    (!oneColumn && invert === 'horizontal') ||
+    (oneColumn && invert === 'vertical')
 
   const primaryContent = (
     <Inside name="Split:primary">
@@ -58,7 +59,7 @@ function Split({ primary, secondary, invert }) {
 }
 
 Split.propTypes = {
-  invert: PropTypes.oneOf(['none', 'rows', 'columns']),
+  invert: PropTypes.oneOf(['none', 'horizontal', 'vertical']),
   primary: PropTypes.node,
   secondary: PropTypes.node,
 }


### PR DESCRIPTION
Usage:

```jsx
<Split
  invert="horizontal"
  primary={
    <div>
      On large viewports, this will get displayed
      on the right side rather than the left.
    </div>
  }
  secondary={
    <div>
      On large viewports, this will get displayed
        on the left side rather than the right.
    </div>
  }
/>
```

Note: “left” and “right” will mean the opposite when right to left support will be added to aragonUI.

```jsx
<Split
  invert="vertical"
  primary={
    <div>
      On small viewports, this will get displayed second.
    </div>
  }
  secondary={
    <div>
      On small viewports, this will get displayed first.
    </div>
  }
/>
```

/cc @onbjerg @deamme 