### PR TITLE
Switch: fix usage in HTML forms

### DIFF
--- a/devbox/apps/Switch.js
+++ b/devbox/apps/Switch.js
@@ -13,10 +13,10 @@ const OptionWrapper = styled.div`
 `
 
 // eslint-disable-next-line react/prop-types
-const Option = ({ name, initiallyChecked, ...passedProps }) => {
+const Option = ({ name, initiallyChecked, asLabel, ...passedProps }) => {
   const [checked, setIsChecked] = useState(Boolean(initiallyChecked))
   return (
-    <OptionWrapper>
+    <OptionWrapper as={asLabel ? 'label' : 'div'}>
       <Text>{name}</Text>
       <Switch onChange={setIsChecked} checked={checked} {...passedProps} />
     </OptionWrapper>
@@ -36,6 +36,7 @@ export default () => {
       <div>
         <Option name="On" initiallyChecked />
         <Option name="Off" />
+        <Option name="Wrapped in a label" asLabel />
         <Option name="Disabled on" initiallyChecked disabled />
         <Option name="Disabled off" disabled />
       </div>

--- a/gallery/src/pages/PageSwitch.js
+++ b/gallery/src/pages/PageSwitch.js
@@ -9,7 +9,7 @@ const Text = styled.span`
   padding-right: 20px;
   min-width: 100px;
 `
-const OptionWrapper = styled.div`
+const OptionWrapper = styled.label`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -26,7 +26,10 @@ function Switch({ checked, disabled, onChange }) {
     <FocusVisible>
       {({ focusVisible, onFocus }) => (
         <span
-          onClick={handleChange}
+          onClick={e => {
+            e.preventDefault()
+            handleChange()
+          }}
           css={`
             position: relative;
             display: inline-block;


### PR DESCRIPTION
When `Switch` (#620) was used as a child of label HTML element, the component
fired callback twice, with different results (on/off). This resulted in an unchanged UI.