### PR TITLE
AutoComplete doc: suggest to limit the number of items

### DIFF
--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -176,8 +176,6 @@ const Items = React.forwardRef(({ theme, ...props }, ref) => (
       padding: 0;
       margin: 0;
       list-style: none;
-      max-height: 250px;
-      overflow-y: scroll;
 
       & ${Item}:first-child {
         border-top-left-radius: 3px;

--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -176,6 +176,8 @@ const Items = React.forwardRef(({ theme, ...props }, ref) => (
       padding: 0;
       margin: 0;
       list-style: none;
+      max-height: 250px;
+      overflow-y: scroll;
 
       & ${Item}:first-child {
         border-top-left-radius: 3px;

--- a/src/components/AutoComplete/README.md
+++ b/src/components/AutoComplete/README.md
@@ -8,7 +8,7 @@ Another component `AutoCompleteSelected` offers the extra functionality to selec
 
 ```jsx
 import { useState } from 'react'
-import { AutoComplete } from '@aragon/ui'
+import { _AutoComplete as AutoComplete } from '@aragon/ui'
 
 const items = [
   'Bruce Wayne',

--- a/src/components/AutoComplete/README.md
+++ b/src/components/AutoComplete/README.md
@@ -48,7 +48,9 @@ const FilterBasedOnWhatIsTyped = () => {
 - Type: `Array`
 - Default: `[]`
 
-Use this property to define the items of the list. Objects can be used but for that you'll have to pass down your own item renderer.
+Use this property to define the items of the list. Objects can be used but that means you’ll have to pass down your own item renderer.
+
+Note: remember to limit the number of `items` to an acceptable number, like 10 items.
 
 ### `renderItem`
 


### PR DESCRIPTION
When we have more items on `AutoComplete` the wrapper expands with the items. Adding max-height fixes this. Hope this is a good PR for the system. Here is the screenshot of the UI before and after style changes:

- Before: 
![Before](https://i.imgur.com/YrjOT7s.png)

- After
![After](https://imgur.com/rWBQufQ.png)