### PR TITLE
tokenIconUrl(): support ETH + update source

### DIFF
--- a/devbox/apps/TokenBadge.js
+++ b/devbox/apps/TokenBadge.js
@@ -16,6 +16,11 @@ class App extends React.Component {
       >
         {[
           {
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'ETH',
+            name: 'Ethereum',
+          },
+          {
             address: '0x960b236a07cf122663c4303350609a66a7b288c0',
             symbol: 'ANT',
             name: 'Aragon',

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -142,7 +142,7 @@ export function blockExplorerUrl(
 /**
  * Get the address of a token icon
  *
- * @param {string} address The contract address of the token, or an empty address (0x000…) to get the Ethereum icon.
+ * @param {string} address The contract address of the token, or the zero address (0x000…) to get the Ethereum icon.
  * @return {string} The generated URL, or an empty string if the parameters are invalid.
  */
 export function tokenIconUrl(address = '') {

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -142,7 +142,7 @@ export function blockExplorerUrl(
 /**
  * Get the address of a token icon
  *
- * @param {string} address The contract address of the token, or "ethereum" to get the Ethereum icon.
+ * @param {string} address The contract address of the token, or an empty address (0x000…) to get the Ethereum icon.
  * @return {string} The generated URL, or an empty string if the parameters are invalid.
  */
 export function tokenIconUrl(address = '') {

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -1,7 +1,11 @@
 import { warn } from './environment'
 
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 const TRANSACTION_REGEX = /^0x[A-Fa-f0-9]{64}$/
 const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
+
+const TRUST_WALLET_BASE_URL =
+  'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum'
 
 const ETHERSCAN_NETWORK_TYPES = new Map([
   ['main', ''],
@@ -138,12 +142,19 @@ export function blockExplorerUrl(
 /**
  * Get the address of a token icon
  *
- * @param {string} address The contract address of the token.
+ * @param {string} address The contract address of the token, or "ethereum" to get the Ethereum icon.
  * @return {string} The generated URL, or an empty string if the parameters are invalid.
  */
 export function tokenIconUrl(address = '') {
   address = address.trim().toLowerCase()
-  return address
-    ? `https://raw.githubusercontent.com/TrustWallet/tokens/master/tokens/${address}.png`
-    : ''
+
+  if (!address) {
+    return ''
+  }
+
+  if (address === EMPTY_ADDRESS) {
+    return `${TRUST_WALLET_BASE_URL}/info/logo.png`
+  }
+
+  return `${TRUST_WALLET_BASE_URL}/assets/${address}/logo.png`
 }


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon-ui/issues/629 and https://github.com/aragon/aragon-ui/issues/624

I went for the `0x000…` solution for now, I think we could do that for now and support other chains whenever it will become needed.