### PR TITLE
tokenIconUrl(): new source format (checksum addresses)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "arg": "^2.0.0",
     "command-exists": "^1.2.6",
     "dayjs": "^1.8.14",
+    "js-sha3": "^0.8.0",
     "lodash-es": "^4.17.15",
     "popper.js": "^1.14.4",
     "prop-types": "^15.6.0",

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -189,14 +189,8 @@ export function blockExplorerUrl(
  * @return {string} The generated URL, or an empty string if the parameters are invalid.
  */
 export function tokenIconUrl(address = '') {
-  address = address.trim().toLowerCase()
-
-  if (!address) {
-    return ''
-  }
-
   try {
-    address = toChecksumAddress(address)
+    address = toChecksumAddress(address.trim())
   } catch (err) {
     return ''
   }

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -1,3 +1,4 @@
+import sha3 from 'js-sha3'
 import { warn } from './environment'
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -38,6 +39,46 @@ const BLOCK_EXPLORERS = {
     const typePart = ETHERSCAN_TYPES.get(type)
     return `https://${subdomain}etherscan.io/${typePart}/${value}`
   },
+}
+
+/**
+ * Converts to a checksum address
+ *
+ * This function is taken from web3-utils:
+ * https://github.com/ethereum/web3.js/blob/22df832303e349f8ae02f0392e56abe10e1dfaac/packages/web3-utils/src/index.js#L287-L315
+ * And was adapted to use js-sha3 rather than soliditySha3.js from web3.js, in
+ * order to avoid adding the BN.js and underscore dependencies.
+ *
+ * @method toChecksumAddress
+ * @param {String} address the given HEX address
+ * @return {String}
+ */
+function toChecksumAddress(address) {
+  if (typeof address === 'undefined') {
+    return ''
+  }
+
+  if (!/^(0x)?[0-9a-f]{40}$/i.test(address)) {
+    throw new Error(
+      'Given address "' + address + '" is not a valid Ethereum address.'
+    )
+  }
+
+  address = address.toLowerCase().replace(/^0x/i, '')
+
+  const addressHash = sha3.keccak_256(address).replace(/^0x/i, '')
+  let checksumAddress = '0x'
+
+  for (let i = 0; i < address.length; i++) {
+    // If ith character is 9 to f then make it uppercase
+    if (parseInt(addressHash[i], 16) > 7) {
+      checksumAddress += address[i].toUpperCase()
+    } else {
+      checksumAddress += address[i]
+    }
+  }
+
+  return checksumAddress
 }
 
 /**
@@ -149,6 +190,12 @@ export function tokenIconUrl(address = '') {
   address = address.trim().toLowerCase()
 
   if (!address) {
+    return ''
+  }
+
+  try {
+    address = toChecksumAddress(address)
+  } catch (err) {
     return ''
   }
 

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -1,6 +1,8 @@
 import sha3 from 'js-sha3'
 import { warn } from './environment'
 
+const { keccak_256: keccak256 } = sha3
+
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 const TRANSACTION_REGEX = /^0x[A-Fa-f0-9]{64}$/
 const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/
@@ -66,7 +68,7 @@ function toChecksumAddress(address) {
 
   address = address.toLowerCase().replace(/^0x/i, '')
 
-  const addressHash = sha3.keccak_256(address).replace(/^0x/i, '')
+  const addressHash = keccak256(address).replace(/^0x/i, '')
   let checksumAddress = '0x'
 
   for (let i = 0; i < address.length; i++) {

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -56,10 +56,6 @@ const BLOCK_EXPLORERS = {
  * @return {String}
  */
 function toChecksumAddress(address) {
-  if (typeof address === 'undefined') {
-    return ''
-  }
-
   if (!/^(0x)?[0-9a-f]{40}$/i.test(address)) {
     throw new Error(
       'Given address "' + address + '" is not a valid Ethereum address.'


### PR DESCRIPTION
The format has recently changed on the [source repository](https://github.com/trustwallet/assets/pull/502), and token icons can now only be accessed through checksum addresses.

web3-utils [is huge](https://bundlephobia.com/result?p=web3-utils@1.2.2), so I copied the `toChecksumAddress()` function there and made it use [js-sha3](https://github.com/emn178/js-sha3), which is [quite small](https://bundlephobia.com/result?p=js-sha3@0.8.0) and [used by ethers.js](https://github.com/ethers-io/ethers.js/blob/76a8e503dd47b8da1961fb85a6ca28d007f49585/utils/keccak256.js), so it seems like a reasonable choice for the time being.

@sohkai let me know what you think! Another approach would be to only support checksum addresses for `TokenBadge`.