### PR TITLE
Gallery dropdown content bug fix & demo enhancement

### DIFF
--- a/gallery/src/pages/PageDropDown.js
+++ b/gallery/src/pages/PageDropDown.js
@@ -18,31 +18,19 @@ class PageDropDown extends React.Component {
 
     return (
       <Page title={title} readme={readme}>
-        <Page.Demo height={350}>
-          <Container>
-            <div
-              style={{
-                display: 'flex',
-                height: '100%',
-                width: '100%',
-                paddingTop: '40px',
-                justifyContent: 'center',
-              }}
-            >
-              <div>
-                <DropDown
-                  active={activeItem}
-                  onChange={this.handleChange}
-                  items={[
-                    'Wandering Thunder',
-                    'Black Wildflower',
-                    'Ancient Paper',
-                    'Green Fire',
-                  ]}
-                />
-              </div>
-            </div>
-          </Container>
+        <Page.Demo container={false}>
+          <div>
+            <DropDown
+              active={activeItem}
+              onChange={this.handleChange}
+              items={[
+                'Wandering Thunder',
+                'Black Wildflower',
+                'Ancient Paper',
+                'Green Fire',
+              ]}
+            />
+          </div>
         </Page.Demo>
       </Page>
     )

--- a/gallery/src/pages/PageDropDown.js
+++ b/gallery/src/pages/PageDropDown.js
@@ -7,7 +7,7 @@ import Container from '../components/Page/DemoContainer'
 
 class PageDropDown extends React.Component {
   state = {
-    activeItem: 0,
+    activeItem: -1,
   }
   handleChange = index => {
     this.setState({ activeItem: index })
@@ -23,6 +23,7 @@ class PageDropDown extends React.Component {
             <DropDown
               active={activeItem}
               onChange={this.handleChange}
+              selected={activeItem}
               items={[
                 'Wandering Thunder',
                 'Black Wildflower',


### PR DESCRIPTION
- Set `container` as `false` on the attached Demo component on the PageDropdown component.
- Remove the `Container` component
- Remove the extra div with css for centering
- Pass the `selected` prop to the dropdown for displaying an item.
- Set the default state of the demo to -1 to display the default placeholder.

This PR closes #670 