### PR TITLE
Solve RootPortal page bug

### DIFF
--- a/gallery/src/pages/PageRootPortal.js
+++ b/gallery/src/pages/PageRootPortal.js
@@ -34,11 +34,7 @@ const PageRootPortal = ({ title }) => {
       >
         This component is rendered {inside ? 'through' : 'without'} RootPortal.
       </div>
-      <Button
-        mode="secondary"
-        size="compact"
-        onClick={() => setInside(v => !v)}
-      >
+      <Button mode="secondary" size="small" onClick={() => setInside(v => !v)}>
         Render {inside ? 'without' : 'through'} RootPortal
       </Button>
     </div>


### PR DESCRIPTION
- Changed size prop from "compact" (deprecated) to "small". This was making the page not render due to an uncaught error.

This PR closes #674 