### PR TITLE
Update colors (dark theme preparation)

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -97,9 +97,9 @@ function modeStyles(theme, mode, disabled) {
     return {
       background: `
         linear-gradient(
-          130deg,
-          ${theme.accentStart},
-          ${theme.accentEnd}
+          190deg,
+          ${theme.accentStart} -100%,
+          ${theme.accentEnd} 80%
         )
       `,
       color: theme.accentContent,

--- a/src/theme/theme-dark.js
+++ b/src/theme/theme-dark.js
@@ -5,7 +5,7 @@ export default {
 
   background: '#28334c',
   border: '#2c3a58',
-  overlay: '#35425e',
+  overlay: '#28334c',
   content: colors.White,
   contentSecondary: '#7c99d6',
 
@@ -69,7 +69,7 @@ export default {
   hint: '#6683c3',
   link: '#0ca5ff',
   focus: '#0ca5ff',
-  selected: '#00d2ff',
+  selected: colors.AragonBlue,
   selectedContent: colors.White,
   selectedDisabled: colors.GreyDark,
 
@@ -84,9 +84,9 @@ export default {
   controlSurface: colors.ArcticBlueLight,
   controlUnder: colors.ArcticBlue,
 
-  accent: '#00d2ff',
-  accentStart: '#00d2ff',
-  accentEnd: '#0aece2',
+  accent: colors.AragonBlue,
+  accentStart: '#32fff5',
+  accentEnd: colors.AragonBlue,
   accentContent: colors.White,
 
   floating: '#1c2539',

--- a/src/theme/theme-light.js
+++ b/src/theme/theme-light.js
@@ -85,8 +85,8 @@ export default {
   controlUnder: colors.GreyBasic,
 
   accent: colors.AragonBlue,
-  accentStart: colors.AragonBlue,
-  accentEnd: colors.AragonTurquoise,
+  accentStart: '#32fff5',
+  accentEnd: colors.AragonBlue,
   accentContent: colors.White,
 
   floating: '#30404F',


### PR DESCRIPTION
- Button: change the gradient orientation.
- Change the accent gradient to improve the contrast.
- In dark mode, change the `selected` color .
- In dark mode, make the `overlay` darker.

Before:<br><img width=60% src=https://user-images.githubusercontent.com/36158/69894414-3ea1b680-12fe-11ea-8762-de8fe67c6345.png>

After:<br><img width=60% src=https://user-images.githubusercontent.com/36158/69894407-2e89d700-12fe-11ea-9eff-67a2245d4924.png>