### PR TITLE
Theme: always extend the base theme

### DIFF
--- a/src/theme/Theme.js
+++ b/src/theme/Theme.js
@@ -21,12 +21,9 @@ function getTheme(theme) {
     warn(`Using the theme “${THEME_DEFAULT}”.`)
     return EMBEDDED_THEMES[THEME_DEFAULT]
   }
+
   if (typeof theme === 'string' && EMBEDDED_THEMES[theme]) {
     return EMBEDDED_THEMES[theme]
-  }
-
-  if (theme === EMBEDDED_THEMES[theme._name]) {
-    return theme
   }
 
   const baseTheme =


### PR DESCRIPTION
Even if the passed theme has the same name than an embedded theme, we now always override it with the passed one.

See discussion https://github.com/aragon/aragon-ui/pull/685/files#r359157304