### PR TITLE
Popover: reject closing

### DIFF
--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -47,7 +47,7 @@ class PopoverBase extends React.Component {
   componentDidMount() {
     this._document = this._popperElement.current.ownerDocument
     this._document.addEventListener('keydown', this.handleEscape)
-    this._cardElement.current.focus()
+    this.focus()
     this.initPopper()
   }
 
@@ -67,6 +67,12 @@ class PopoverBase extends React.Component {
     ) {
       this.destroyPopper()
       this.initPopper()
+    }
+  }
+
+  focus() {
+    if (this._cardElement.current) {
+      this._cardElement.current.focus()
     }
   }
 
@@ -120,16 +126,15 @@ class PopoverBase extends React.Component {
   }
 
   handleEscape = ({ keyCode }) => {
-    const { opener, onClose } = this.props
     if (keyCode === KEY_ESC) {
       // On escape, we always move the focus back to the opener.
-      opener.focus()
-      onClose()
+      this.props.opener.focus()
+      this.attemptClose()
     }
   }
 
   handleBlur = event => {
-    const { closeOnOpenerFocus, opener, onClose } = this.props
+    const { closeOnOpenerFocus, opener } = this.props
     const focusedElement = event.relatedTarget
 
     // Do not close if:
@@ -159,7 +164,17 @@ class PopoverBase extends React.Component {
     if (!focusedElement) {
       opener.focus()
     }
-    onClose()
+    this.attemptClose()
+  }
+
+  attemptClose() {
+    const accepted = this.props.onClose()
+
+    // If closing the popover is not accepted, we need to focus it again so
+    // that it can react to onBlur events.
+    if (accepted === false) {
+      this.focus()
+    }
   }
 
   boundaryDimensions() {

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -69,7 +69,7 @@ zIndex of Popover.
 | ---------- | ------------- |
 | `Function` | None          |
 
-The callback that is called when the popover request to be closed.
+The callback that is called when the popover request to be closed. If this callback returns `false`, the popover will get focused again. This is useful to ensure that the `blur` event still gets triggered after a close request got rejected.
 
 ### `visible`
 


### PR DESCRIPTION
I’m wondering if a more transparent approach could be to wait for the next tick, then focus again if `visible` is still `true`.