### PR TITLE
Dark mode support for AutoComplete

### DIFF
--- a/src/components/AutoComplete/AutoComplete.js
+++ b/src/components/AutoComplete/AutoComplete.js
@@ -169,7 +169,7 @@ const Item = React.forwardRef(function Item(
           ${selected
             ? `
                 outline: 2px solid ${theme.accent};
-                background: #f9fafc;
+                background: ${theme.surfaceHighlight};
                 border-left: 3px solid ${theme.accent};
               `
             : ''};

--- a/src/components/AutoComplete/AutoCompleteSelected.js
+++ b/src/components/AutoComplete/AutoCompleteSelected.js
@@ -71,6 +71,7 @@ function AutoCompleteSelected({
 
   return (
     <AutoComplete
+      itemButtonStyles={itemButtonStyles}
       items={items}
       onChange={onChange}
       onSelect={handleSelect}


### PR DESCRIPTION
This PR updates AutoComplete to support dark mode. Additionally, AutoCompleteSelected has been updated to pass `itenButtonStyles` props to the AutoComplete component.

Before:
![Screenshot from 2020-02-07 15-28-20](https://user-images.githubusercontent.com/19808076/74073395-0afaa100-49bf-11ea-8b25-e1291f0addda.png)

After:
![Screenshot from 2020-02-07 15-25-57](https://user-images.githubusercontent.com/19808076/74073402-1057eb80-49bf-11ea-82a7-cc7022a967f7.png)
