### PR TITLE
Timer show icon prop

### DIFF
--- a/src/components/Timer/README.md
+++ b/src/components/Timer/README.md
@@ -26,33 +26,42 @@ const App = () => (
 
 ### `end`
 
-- Type: `Date`
+| Type      | Default value |
+| --------- | ------------- |
+| `Date`    | None          |
 
 The end of the countdown, as a `Date` instance.
 
 ### `start`
 
-- Type: `Date`
+| Type      | Default value |
+| --------- | ------------- |
+| `Date`    | None          |
 
 The start of a timer, as a `Date` instance.
 
 ### `format`
 
-- Type `Enum: [ 'yMdhms', 'yMdhm', 'yMdh','yMd', 'yM', 'Mdhms', 'Mdhm', 'Mdh', 'Md', 'dhms', 'dhm', 'hms', 'hm', 'ms', 'm', 's' ]`
-- Default: `'dhms'`
+| Type      | Default value |
+| --------- | ------------- |
+| `Enum`    | `'dhms'`      |
+
+- Options: `[ 'yMdhms', 'yMdhm', 'yMdh','yMd', 'yM', 'Mdhms', 'Mdhm', 'Mdh', 'Md', 'dhms', 'dhm', 'hms', 'hm', 'ms', 'm', 's' ]`
 
 Format output in years 'y', months 'M', days 'd', hours 'h', minutes 'm', seconds 's'
 
 ### `showEmpty`
 
-- Type `Boolean`
-- Default: `false`
+| Type         | Default value |
+| ------------ | ------------- |
+| `Boolean`    | `False`       |
 
 Display the units on the left side of the timer when they are equal to zero.
 
 ### `showIcon`
 
-- Type `Boolean`
-- Default: `true`
+| Type         | Default value |
+| ------------ | ------------- |
+| `Boolean`    | `True`        |
 
 Display the clock icon on the left side of the timer.

--- a/src/components/Timer/README.md
+++ b/src/components/Timer/README.md
@@ -49,3 +49,10 @@ Format output in years 'y', months 'M', days 'd', hours 'h', minutes 'm', second
 - Default: `false`
 
 Display the units on the left side of the timer when they are equal to zero.
+
+### `showIcon`
+
+- Type `Boolean`
+- Default: `true`
+
+Display the clock icon on the left side of the timer.

--- a/src/components/Timer/Timer.js
+++ b/src/components/Timer/Timer.js
@@ -80,6 +80,7 @@ class Timer extends React.Component {
     format: PropTypes.oneOf(Object.keys(formats)),
     maxUnits: PropTypes.number,
     showEmpty: PropTypes.bool,
+    showIcon: PropTypes.bool,
     start: PropTypes.instanceOf(Date),
     theme: PropTypes.object,
   }
@@ -87,10 +88,11 @@ class Timer extends React.Component {
     format: formats.yMdhms,
     maxUnits: -1,
     showEmpty: false,
+    showIcon: true,
   }
 
   render() {
-    const { end, start, theme } = this.props
+    const { end, start, showIcon, theme } = this.props
     return (
       <time
         dateTime={formatHtmlDatetime(end || start)}
@@ -102,20 +104,22 @@ class Timer extends React.Component {
           ${textStyle('body2')};
         `}
       >
-        <span
-          css={`
-            display: flex;
-            align-items: center;
-            margin-right: ${0.5 * GU}px;
-            margin-top: -3px;
-          `}
-        >
-          <IconTime
+        {showIcon && (
+          <span
             css={`
-              color: ${theme.surfaceIcon};
+              display: flex;
+              align-items: center;
+              margin-right: ${0.5 * GU}px;
+              margin-top: -3px;
             `}
-          />
-        </span>
+          >
+            <IconTime
+              css={`
+                color: ${theme.surfaceIcon};
+              `}
+            />
+          </span>
+        )}
         <Redraw interval={RENDER_EVERY}>{this.renderTime}</Redraw>
       </time>
     )

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -70,8 +70,12 @@ export { default as TextCopy } from './TextCopy/TextCopy'
 export { default as TextInput } from './Input/TextInput'
 export { default as Timer } from './Timer/Timer'
 export { default as TokenBadge } from './TokenBadge/TokenBadge'
-export { default as TransactionBadge } from './TransactionBadge/TransactionBadge'
-export { default as TransactionProgress } from './TransactionProgress/TransactionProgress'
+export {
+  default as TransactionBadge,
+} from './TransactionBadge/TransactionBadge'
+export {
+  default as TransactionProgress,
+} from './TransactionProgress/TransactionProgress'
 
 // Deprecated / to be deprecated components
 export { default as AppBar } from './AppView/AppBar'
@@ -83,4 +87,6 @@ export { default as Text } from './Text/Text'
 
 // Experimental components
 export { default as _AutoComplete } from './AutoComplete/AutoComplete'
-export { default as _AutoCompleteSelected } from './AutoComplete/AutoCompleteSelected'
+export {
+  default as _AutoCompleteSelected,
+} from './AutoComplete/AutoCompleteSelected'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -70,12 +70,8 @@ export { default as TextCopy } from './TextCopy/TextCopy'
 export { default as TextInput } from './Input/TextInput'
 export { default as Timer } from './Timer/Timer'
 export { default as TokenBadge } from './TokenBadge/TokenBadge'
-export {
-  default as TransactionBadge,
-} from './TransactionBadge/TransactionBadge'
-export {
-  default as TransactionProgress,
-} from './TransactionProgress/TransactionProgress'
+export { default as TransactionBadge } from './TransactionBadge/TransactionBadge'
+export { default as TransactionProgress } from './TransactionProgress/TransactionProgress'
 
 // Deprecated / to be deprecated components
 export { default as AppBar } from './AppView/AppBar'
@@ -87,6 +83,4 @@ export { default as Text } from './Text/Text'
 
 // Experimental components
 export { default as _AutoComplete } from './AutoComplete/AutoComplete'
-export {
-  default as _AutoCompleteSelected,
-} from './AutoComplete/AutoCompleteSelected'
+export { default as _AutoCompleteSelected } from './AutoComplete/AutoCompleteSelected'


### PR DESCRIPTION
Adding this new prop so we can choose to not show the clock icon.

This will be useful for the court dashboard. See https://github.com/aragon/court-dashboard/pull/227#discussion_r389214082