### PR TITLE
Packages: Prettier version upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jest": "^24.8.0",
     "lint-staged": "^8.1.0",
     "listr": "^0.14.3",
-    "prettier": "^1.17.1",
+    "prettier": "^1.19.0",
     "rollup": "^1.30.1",
     "rollup-plugin-analyzer": "^3.2.2",
     "rollup-plugin-babel": "^4.0.3",


### PR DESCRIPTION
Update prettier version to 1.19.0 since there is there are differences on the column limit between the versions