### PR TITLE
Theme: warn when invalid colors are being accessed

### DIFF
--- a/devbox/apps/TransactionProgress.js
+++ b/devbox/apps/TransactionProgress.js
@@ -12,7 +12,15 @@ class App extends React.Component {
     const { title } = this.props
     return (
       <Root.Provider>
-        <Wrapper>
+        <div
+          css={`
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 100%;
+            height: 100vh;
+          `}
+        >
           <div ref={this.handleRef}>
             <Button
               ref={this._opener}
@@ -32,30 +40,10 @@ class App extends React.Component {
               slow
             />
           </div>
-        </Wrapper>
+        </div>
       </Root.Provider>
     )
   }
 }
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 100vh;
-`
-
-const Box = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 200px;
-  height: 100px;
-  background: ${theme.contentBackground};
-  border: 1px solid ${theme.contentBorder};
-  border-radius: 3px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-`
 
 export default App

--- a/src/components/Tabs/TabBarLegacy.js
+++ b/src/components/Tabs/TabBarLegacy.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { theme } from '../../theme-legacy'
 import { font, unselectable, noop } from '../../utils'
 
 class TabBar extends React.Component {
@@ -92,43 +91,81 @@ class TabBar extends React.Component {
   }
 }
 
-const Bar = styled.ul`
-  display: flex;
-  border-bottom: ${p => (p.border ? `1px solid ${theme.contentBorder}` : '0')};
-`
+function Bar({ children, border }) {
+  const theme = useTheme()
+  return (
+    <ul
+      css={`
+        display: flex;
+        border-bottom: ${border ? `1px solid ${theme.border}` : '0'};
+      `}
+    >
+      {children}
+    </ul>
+  )
+}
 
-const FocusRing = styled.span`
-  display: none;
-  position: absolute;
-  top: -5px;
-  left: -5px;
-  right: -5px;
-  bottom: -5px;
-  border: 2px solid ${theme.accent};
-  border-radius: 2px;
-`
+function FocusRing({ children }) {
+  const theme = useTheme()
+  return (
+    <span
+      className="TabBarLegacy-FocusRing"
+      css={`
+        display: none;
+        position: absolute;
+        top: -5px;
+        left: -5px;
+        right: -5px;
+        bottom: -5px;
+        border: 2px solid ${theme.accent};
+        border-radius: 2px;
+      `}
+    >
+      {children}
+    </span>
+  )
+}
 
-const Tab = styled.li`
-  position: relative;
-  list-style: none;
-  padding: 0 30px;
-  cursor: pointer;
-  ${p =>
-    font({ weight: p.selected ? 'bold' : 'normal', deprecationNotice: false })};
-  ${unselectable()};
-  &:focus {
-    outline: 0;
-    ${FocusRing} {
-      display: block;
-    }
-  }
-`
+function Tab({ children, selected }) {
+  return (
+    <li
+      css={`
+        position: relative;
+        list-style: none;
+        padding: 0 30px;
+        cursor: pointer;
+        ${font({
+          weight: selected ? 'bold' : 'normal',
+          deprecationNotice: false,
+        })};
+        ${unselectable()};
+        &:focus {
+          outline: 0;
+          .TabBarLegacy-FocusRing {
+            display: block;
+          }
+        }
+      `}
+    >
+      {children}
+    </li>
+  )
+}
 
-const Label = styled.span`
-  display: flex;
-  margin-bottom: -1px;
-  padding: 5px 0 3px;
-  border-bottom: 4px solid ${p => (p.selected ? theme.accent : 'transparent')};
-`
+function Label({ children }) {
+  const theme = useTheme()
+  return (
+    <span
+      css={`
+        display: flex;
+        margin-bottom: -1px;
+        padding: 5px 0 3px;
+        border-bottom: 4px solid ${selected ? theme.accent : 'transparent'};
+      `}
+    >
+      {children}
+    </span>
+  )
+}
 
 export default TabBar

--- a/src/components/Tabs/TabBarLegacy.js
+++ b/src/components/Tabs/TabBarLegacy.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import { useTheme } from '../../theme'
 import { font, unselectable, noop } from '../../utils'
 
 class TabBar extends React.Component {
@@ -91,6 +91,8 @@ class TabBar extends React.Component {
   }
 }
 
+/* eslint-disable react/prop-types */
+
 function Bar({ children, border }) {
   const theme = useTheme()
   return (
@@ -152,7 +154,7 @@ function Tab({ children, selected }) {
   )
 }
 
-function Label({ children }) {
+function Label({ children, selected }) {
   const theme = useTheme()
   return (
     <span

--- a/src/theme-legacy/palettes.js
+++ b/src/theme-legacy/palettes.js
@@ -1,3 +1,4 @@
+import { warn, warnOnce } from '../utils'
 import aragon from './aragon'
 
 // These need to match the names in the Open Color palettes
@@ -44,7 +45,7 @@ const resolveColors = (palette, palettes) =>
   }, {})
 
 // Prepare groups from the palettes: theme, themeDark, brand and colors.
-const groups = palettes =>
+const generateGroups = palettes =>
   Object.entries(palettes).reduce(
     (groups, [paletteName, palette]) => {
       const groupName = getGroupName(paletteName)
@@ -60,7 +61,29 @@ const groups = palettes =>
     { colors: {} }
   )
 
-const { themeDark, theme, brand, colors } = groups(aragon)
+// Deprecate any access to the palettes
+const { themeDark, theme, brand, colors } = Object.fromEntries(
+  Object.entries(generateGroups(aragon)).map(([name, group]) => [
+    name,
+    new Proxy(group, {
+      get(group, colorName) {
+        if (group[colorName]) {
+          warnOnce(
+            `theme-legacy:${name}.${colorName}`,
+            `${name}.${colorName} was accessed but ${name} will be removed soon, ` +
+              `please use useTheme() instead.`
+          )
+        } else {
+          warn(
+            `${name}.${colorName} doesn’t exist. ${name} will be removed soon, ` +
+              `please use useTheme() instead.`
+          )
+        }
+        return group[colorName]
+      },
+    }),
+  ])
+)
 
 // TODO: show a deprecating warning when any of these colors get accessed once.
 export { themeDark, theme, brand, colors }

--- a/src/theme/Theme.js
+++ b/src/theme/Theme.js
@@ -40,7 +40,7 @@ function getTheme(theme) {
   return { ...baseTheme, ...theme }
 }
 
-const ThemeContext = React.createContext(prepareTheme(getTheme(THEME_DEFAULT)))
+const ThemeContext = React.createContext(null)
 
 function convertThemeColor(name, value) {
   if (RESERVED_KEYS.includes(name)) {

--- a/src/theme/Theme.js
+++ b/src/theme/Theme.js
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { color, warn } from '../utils'
+import { color, warnOnce } from '../utils'
 import dark from './theme-dark'
 import light from './theme-light'
 
@@ -12,13 +12,21 @@ const EMBEDDED_THEMES = { dark, light }
 const THEME_DEFAULT = 'light'
 
 const RESERVED_KEYS = ['_appearance', '_name']
+const DEPRECATED_COLORS = new Map([
+  ['error', 'negative'],
+  ['success', 'positive'],
+])
 
 const COLOR_FALLBACK = '#FF00FF'
 
 function getTheme(theme) {
-  if (!validateTheme(theme)) {
-    warn('Theme invalid:', theme)
-    warn(`Using the theme “${THEME_DEFAULT}”.`)
+  const validationError = validateTheme(theme)
+  if (validationError !== null) {
+    warnOnce(
+      `theme:theme-invalid:${validationError}`,
+      `Theme invalid: ${validationError}. ` +
+        `Using the theme “${THEME_DEFAULT}” instead.`
+    )
     return EMBEDDED_THEMES[THEME_DEFAULT]
   }
 
@@ -32,9 +40,7 @@ function getTheme(theme) {
   return { ...baseTheme, ...theme }
 }
 
-const ThemeContext = React.createContext(
-  convertThemeColors(getTheme(THEME_DEFAULT))
-)
+const ThemeContext = React.createContext(prepareTheme(getTheme(THEME_DEFAULT)))
 
 function convertThemeColor(name, value) {
   if (RESERVED_KEYS.includes(name)) {
@@ -48,22 +54,60 @@ function convertThemeColor(name, value) {
   }
 }
 
-function convertThemeColors(theme) {
-  return Object.entries(theme).reduce((theme, [name, value]) => {
-    let convertedValue = convertThemeColor(name, value)
-
-    return {
-      ...theme,
-      [name]: convertedValue,
-    }
-  }, {})
+// prepareTheme() does a few things:
+// - Wrap every color in a color() object (see utils/color.js).
+// - Filter out invalid colors added in custom themes.
+// - Wraps the theme in a proxy that warns about deprecated colors.
+function prepareTheme(theme) {
+  const themeConverted = Object.fromEntries(
+    Object.entries(theme)
+      .filter(([name]) => {
+        if (!EMBEDDED_THEMES[THEME_DEFAULT][name]) {
+          warnOnce(
+            `theme:invalid:${name}`,
+            `Theme: the color “${name}” is invalid and will be ignored. ` +
+              `Please check src/theme/theme-light.js in the aragonUI ` +
+              `repository for a list of valid colors.`
+          )
+          return false
+        }
+        return true
+      })
+      .map(([name, value]) => [name, convertThemeColor(name, value)])
+  )
+  return new Proxy(themeConverted, {
+    get(theme, name) {
+      if (DEPRECATED_COLORS.has(name)) {
+        warnOnce(
+          `theme:deprecated:${name}`,
+          `useTheme(): the color “${name}” has been deprecated and will be removed soon. ` +
+            `Please use “${DEPRECATED_COLORS.get(name)}” instead.`
+        )
+        return theme[DEPRECATED_COLORS.get(name)]
+      }
+      if (!theme[name]) {
+        warnOnce(
+          `theme:unknown:${name}`,
+          `useTheme(): the color “${name}” doesn’t exist in the theme.`
+        )
+        return COLOR_FALLBACK
+      }
+      return theme[name]
+    },
+  })
 }
 
 function validateTheme(theme) {
-  return (
-    (typeof theme === 'string' && EMBEDDED_THEMES[theme]) ||
-    (theme && theme._name && APPEARANCES.includes(theme._appearance))
-  )
+  if (typeof theme === 'string') {
+    return EMBEDDED_THEMES[theme] ? null : `the theme “${theme}” doesn’t exist`
+  }
+  if (theme && !theme._name) {
+    return `the “_name” key of the theme is missing`
+  }
+  if (theme && !APPEARANCES.includes(theme._appearance)) {
+    return `the “_appearance” key of the theme is missing`
+  }
+  return null
 }
 
 function Theme({ theme, children }) {
@@ -71,9 +115,7 @@ function Theme({ theme, children }) {
     theme = THEME_DEFAULT
   }
 
-  const themeConverted = useMemo(() => convertThemeColors(getTheme(theme)), [
-    theme,
-  ])
+  const themeConverted = useMemo(() => prepareTheme(getTheme(theme)), [theme])
 
   return (
     <ThemeContext.Provider value={themeConverted}>

--- a/src/theme/theme-dark.js
+++ b/src/theme/theme-dark.js
@@ -94,8 +94,4 @@ export default {
   blue: '#3E7BF6',
   brown: '#876559',
   purple: '#7C80F2',
-
-  // deprecated
-  error: '#FF6969',
-  success: '#2cc68f',
 }

--- a/src/theme/theme-light.js
+++ b/src/theme/theme-light.js
@@ -94,8 +94,4 @@ export default {
   blue: '#3E7BF6',
   brown: '#876559',
   purple: '#7C80F2',
-
-  // deprecated
-  error: '#FF6969',
-  success: '#2CC68F',
 }


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon-ui/issues/476

Warn in the following cases:

- Deprecated colors.
- Unknown colors.
- Invalid theme.

Also:

- Move TabBarLegacy to `useTheme()`.
- Move deprecated colors in `Theme.js`, rather than in every theme.
