### PR TITLE
useKeyDown: propagate event's keycode to handler

### DIFF
--- a/src/hooks/useKeyDown.js
+++ b/src/hooks/useKeyDown.js
@@ -6,7 +6,7 @@ export function useKeyDown(key, callback) {
   const handleKeyDown = useCallback(
     event => {
       if (keys.includes(event.keyCode)) {
-        callback(event.keyCode)
+        callback(event.keyCode, event)
       }
     },
     [callback, keys]

--- a/src/hooks/useKeyDown.js
+++ b/src/hooks/useKeyDown.js
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 export function useKeyDown(key, callback) {
   const keys = useMemo(() => (Array.isArray(key) ? key : [key]), [key])
 
-  const handlekeyDown = useCallback(
+  const handleKeyDown = useCallback(
     event => {
       if (keys.includes(event.keyCode)) {
         callback(event.keyCode)
@@ -16,9 +16,9 @@ export function useKeyDown(key, callback) {
     if (typeof window === 'undefined') {
       return
     }
-    window.addEventListener('keydown', handlekeyDown)
+    window.addEventListener('keydown', handleKeyDown)
     return () => {
-      window.removeEventListener('keydown', handlekeyDown)
+      window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [handlekeyDown])
+  }, [handleKeyDown])
 }

--- a/src/hooks/useKeyDown.js
+++ b/src/hooks/useKeyDown.js
@@ -6,7 +6,7 @@ export function useKeyDown(key, callback) {
   const handlekeyDown = useCallback(
     event => {
       if (keys.includes(event.keyCode)) {
-        callback()
+        callback(event.keyCode)
       }
     },
     [callback, keys]


### PR DESCRIPTION
In cases where there are multiple keycodes listened to, this allows the handler to know which key was pressed and how to handle it.