### PR TITLE
Docs: fix sample code, component import was missing

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -113,7 +113,7 @@ To make things a bit more interesting, we are going to add a [SidePanel](https:/
 ```jsx
 // App.js
 import React, { useState } from 'react'
-import { Main, Header, Button, IconPlus, SidePanel } from '@aragon/ui'
+import { Main, Header, Button, IconPlus, Tag, SidePanel } from '@aragon/ui'
 
 function App() {
   const [sidePanelOpened, setSidePanelOpened] = useState(false)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -81,7 +81,7 @@ This is how **Header** can be used inside an app.
 ```jsx
 // App.js
 import React from 'react'
-import { Main, Header, Button, IconPlus } from '@aragon/ui'
+import { Main, Header, Button, IconPlus, Tag } from '@aragon/ui'
 
 function App() {
   return (


### PR DESCRIPTION
On GettingStarted.md, there was a sample code block that was using `<Tag>`component, but it wasn't being imported.