### PR TITLE
Toast: fix alignment

### DIFF
--- a/gallery/src/pages/PageToastHub.js
+++ b/gallery/src/pages/PageToastHub.js
@@ -16,23 +16,21 @@ const Container = styled(DemoContainer)`
 `
 
 const PageToastHub = ({ title }) => (
-  <ToastHub>
-    <Page title={title} readme={readme}>
-      <Page.Demo opaque>
-        <Container>
-          <div>
-            <Toast>
-              {toast => (
-                <Button mode="strong" compact onClick={() => toast('hello')}>
-                  Add toast
-                </Button>
-              )}
-            </Toast>
-          </div>
-        </Container>
-      </Page.Demo>
-    </Page>
-  </ToastHub>
+  <Page title={title} readme={readme}>
+    <Page.Demo opaque>
+      <Container>
+        <div>
+          <Toast>
+            {toast => (
+              <Button mode="strong" compact onClick={() => toast('hello')}>
+                Add toast
+              </Button>
+            )}
+          </Toast>
+        </div>
+      </Container>
+    </Page.Demo>
+  </Page>
 )
 
 export default PageToastHub

--- a/src/components/Radio/RadioListItem.js
+++ b/src/components/Radio/RadioListItem.js
@@ -25,7 +25,6 @@ const RadioListItem = React.memo(function RadioListItem({
         id={index}
         css={`
           flex-shrink: 0;
-          margin-top: 1px;
         `}
       />
       <div

--- a/src/components/Radio/RadioListItem.js
+++ b/src/components/Radio/RadioListItem.js
@@ -25,7 +25,7 @@ const RadioListItem = React.memo(function RadioListItem({
         id={index}
         css={`
           flex-shrink: 0;
-          margin-top: ${2 * GU}px;
+          margin-top: 1px;
         `}
       />
       <div

--- a/src/components/ToastHub/ToastHub.js
+++ b/src/components/ToastHub/ToastHub.js
@@ -204,14 +204,13 @@ const ToastList = React.memo(function ToastList({
             >
               <div
                 css={`
-                  display: grid;
-                  grid-template-columns: 1fr;
-                  grid-gap: 10px;
-                  height: ${6 * GU}px;
-                  padding: ${2 * GU}px ${2.5 * GU}px;
+                  display: flex;
+                  align-items: center;
                   overflow: hidden;
+                  height: ${6 * GU}px;
                   margin-top: ${top ? '0' : `${1.25 * GU}px`};
                   margin-bottom: ${top ? `${1.25 * GU}px` : '0'};
+                  padding: 0 ${2.5 * GU}px;
                   ${textStyle('body3')};
                   color: ${theme.floatingContent};
                   background: ${theme.floating.alpha(0.95)};


### PR DESCRIPTION
Also:
- Move to Flexbox.
- Remove unnecessary `<ToastHub>` on the gallery page.