### PR TITLE
IdentityBadge: default labelStyle to avoid `undefined` css

### DIFF
--- a/src/components/IdentityBadge/IdentityBadge.js
+++ b/src/components/IdentityBadge/IdentityBadge.js
@@ -122,6 +122,7 @@ IdentityBadge.propTypes = {
 
 IdentityBadge.defaultProps = {
   entity: '',
+  labelStyle: '',
   networkType: 'main',
   shorten: true,
 }


### PR DESCRIPTION
Oops, since we always do `${labelStyle}` when passing it to the `BadgeBase`, it gets rendered into an `undefined` css class.