### PR TITLE
Dark theme: Increase positive content contrast

### DIFF
--- a/src/theme/theme-dark.js
+++ b/src/theme/theme-dark.js
@@ -44,7 +44,7 @@ export default {
   positive: '#2cc68f',
   positiveContent: '#FFFFFF',
   positiveSurface: '#35585e',
-  positiveSurfaceContent: '#1B8962',
+  positiveSurfaceContent: '#27a779',
 
   badge: '#415279',
   badgeContent: '#ffffff',

--- a/src/theme/theme-dark.js
+++ b/src/theme/theme-dark.js
@@ -44,7 +44,7 @@ export default {
   positive: '#2cc68f',
   positiveContent: '#FFFFFF',
   positiveSurface: '#35585e',
-  positiveSurfaceContent: '#27a779',
+  positiveSurfaceContent: '#2cc68f',
 
   badge: '#415279',
   badgeContent: '#ffffff',


### PR DESCRIPTION
I found `positiveSurfaceContent` to lack contrast in the dark theme. It might just be the context i've been using it but even still it felt on the low side.

![image](https://user-images.githubusercontent.com/11708259/84374174-89698880-abd5-11ea-895f-f157d0b94ba8.png)
