### PR TITLE
docs: update 1hive broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please have a look at [CONTRIBUTING.md](CONTRIBUTING.md).
 
 - [Aragon client](https://github.com/aragon/aragon) and [core apps](https://github.com/aragon/aragon-apps)
 - [Autark’s Open Enterprise](https://www.autark.xyz/apps)
-- [1Hive’s Dandelion apps](https://1hive.org/projects/dandelion-orgs/dandelion-overview)
+- [1Hive’s Dandelion apps](https://github.com/1Hive/dandelion-template)
 - [Aragon Black’s Fundraising](https://fundraising.aragon.black/)
 - [pando](https://github.com/pandonetwork/pando)
 - [P2P Models Wiki](https://github.com/P2PModels/wiki)


### PR DESCRIPTION
The [old link](https://1hive.org/projects/dandelion-orgs/dandelion-overview/) was giving this 404 response:

<img width="593" alt="Capture d’écran 2020-06-16 à 12 48 26" src="https://user-images.githubusercontent.com/8782666/84760354-90770900-afd0-11ea-8f43-8e922c75b685.png">
