### PR TITLE
Modal: Prevent EscapeOutside from causing problems with internal interactions

### DIFF
--- a/src/components/EscapeOutside/EscapeOutside.js
+++ b/src/components/EscapeOutside/EscapeOutside.js
@@ -20,15 +20,16 @@ class EscapeOutside extends React.Component {
   componentDidMount() {
     const { useCapture } = this.props
     this._document = this._element.ownerDocument
-    this._document.addEventListener('keydown', this.handleEscape)
+    this._document.addEventListener('keydown', this.handleEscape, useCapture)
     this._document.addEventListener('click', this.handleClick, useCapture)
     this._document.addEventListener('touchend', this.handleClick, useCapture)
   }
 
   componentWillUnmount() {
-    this._document.removeEventListener('keydown', this.handleEscape)
-    this._document.removeEventListener('click', this.handleClick)
-    this._document.removeEventListener('touchend', this.handleClick)
+    const { useCapture } = this.props
+    this._document.removeEventListener('keydown', this.handleEscape, useCapture)
+    this._document.removeEventListener('click', this.handleClick, useCapture)
+    this._document.removeEventListener('touchend', this.handleClick, useCapture)
   }
 
   handleClick = e => {
@@ -46,7 +47,7 @@ class EscapeOutside extends React.Component {
   }
 
   render() {
-    const { children, onEscapeOutside, ...rest } = this.props
+    const { children, onEscapeOutside, useCapture, ...rest } = this.props
 
     return (
       <div {...rest} ref={n => (this._element = n)}>

--- a/src/components/EscapeOutside/EscapeOutside.js
+++ b/src/components/EscapeOutside/EscapeOutside.js
@@ -6,7 +6,7 @@ class EscapeOutside extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     onEscapeOutside: PropTypes.func.isRequired,
-    useCapture: PropTypes.node,
+    useCapture: PropTypes.bool,
   }
 
   static defaultProps = {

--- a/src/components/EscapeOutside/EscapeOutside.js
+++ b/src/components/EscapeOutside/EscapeOutside.js
@@ -6,20 +6,23 @@ class EscapeOutside extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     onEscapeOutside: PropTypes.func.isRequired,
+    useCapture: PropTypes.node,
   }
 
   static defaultProps = {
     onEscapeOutside: noop,
+    useCapture: false,
   }
 
   _element = React.createRef()
   _document = null
 
   componentDidMount() {
+    const { useCapture } = this.props
     this._document = this._element.ownerDocument
     this._document.addEventListener('keydown', this.handleEscape)
-    this._document.addEventListener('click', this.handleClick)
-    this._document.addEventListener('touchend', this.handleClick)
+    this._document.addEventListener('click', this.handleClick, useCapture)
+    this._document.addEventListener('touchend', this.handleClick, useCapture)
   }
 
   componentWillUnmount() {

--- a/src/components/EscapeOutside/README.md
+++ b/src/components/EscapeOutside/README.md
@@ -32,7 +32,7 @@ The callback to call after clicking outside of the wrapped element, or when pres
 
 If `useCapture` is true, the event will be registered in the capturing phase and thus, propagated top-down instead of bottom-up as is the default.
 
-See (MDN web docs)[https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture] for more information on event bubbling vs capture.
+See the (MDN web docs)[https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture] for more information on event bubbling vs capture.
 
 ### `children`
 

--- a/src/components/EscapeOutside/README.md
+++ b/src/components/EscapeOutside/README.md
@@ -1,0 +1,43 @@
+# EscapeOutside
+
+A component for handling outside clicks.
+
+## Usage
+
+```jsx
+import { EscapeOutside } from '@aragon/ui'
+
+const App = () => (
+  <EscapeOutside useCapture onEscapeOutside={handleOutsideInteraction}>
+    {/* content */}
+  </EscapeOutside>
+)
+```
+
+## Props
+
+### `onEscapeOutside`
+
+| Type       | Default value   |
+| ---------- | --------------- |
+| `Function` | None (required) |
+
+The callback to call after clicking outside of the wrapped element, or when pressing the `ESC` key.
+
+### `useCapture`
+
+| Type      | Default value |
+| --------- | ------------- |
+| `Boolean` | false         |
+
+If `useCapture` is true, the event will be registered in the capturing phase and thus, propagated top-down instead of bottom-up as is the default.
+
+See (MDN web docs)[https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture] for more information on event bubbling vs capture.
+
+### `children`
+
+| Type         | Default value   |
+| ------------ | --------------- |
+| `React node` | None (required) |
+
+The inner content to check when determining whether to trigger an outside event.

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -79,6 +79,7 @@ function Modal({
                 >
                   <EscapeOutside
                     role="alertdialog"
+                    useCapture
                     background={theme.surface}
                     onEscapeOutside={onClose}
                     css={`


### PR DESCRIPTION
resolves https://github.com/aragon/aragon-ui/issues/790

I've added a `useCapture` prop to `EscapeOutside` to allow us to optionally change the event propagation from bubbling to capture, this allows us to reverse execution order on the events, this is especially important for the `Modal` so that outside interaction checks can happen before others potentially affect render state.

More info: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#Event_bubbling_and_capture

![image](https://user-images.githubusercontent.com/11708259/88411276-903c0b80-cdcf-11ea-9cf2-50b68f504f82.png)

