### PR TITLE
TokenAmount: Hold token space during image load

### DIFF
--- a/src/components/TokenAmount/TokenAmount.js
+++ b/src/components/TokenAmount/TokenAmount.js
@@ -44,10 +44,9 @@ const TokenAmount = React.memo(function TokenAmount({
         {amount && (
           <span
             css={`
-              padding-right: ${size === 'large' ? 0.5 * GU : 0.25 * GU}px;
+              margin-right: ${size === 'large' ? 0.5 * GU : 0.25 * GU}px;
               ${textStyle(size === 'large' ? 'title2' : 'body2')};
               line-height: 1;
-              ${size === 'large' ? `transform: translateY(2px);` : ''}
             `}
           >
             {TokenAmountLib.format(amount, decimals, { digits: digits })}
@@ -60,19 +59,30 @@ const TokenAmount = React.memo(function TokenAmount({
 })
 
 const Icon = function Icon({ address, chainId, iconUrl, size }) {
+  const theme = useTheme()
   const token = useToken(chainId === 1 ? address : '')
   const { exists } = useImageExists(iconUrl || token.iconUrl)
   return (
-    exists && (
-      <img
-        alt=""
-        height={3 * GU}
-        src={iconUrl || token.iconUrl}
-        css={`
-          padding-right: ${size === 'large' ? 1 * GU : 0.5 * GU}px;
-        `}
-      />
-    )
+    <div
+      css={`
+        display: flex;
+        width: ${3 * GU}px;
+        height: ${3 * GU}px;
+        margin-right: ${size === 'large' ? 1 * GU : 0.75 * GU}px;
+      `}
+    >
+      {exists ? (
+        <img alt="" width="100%" src={iconUrl || token.iconUrl} />
+      ) : (
+        <div
+          css={`
+            flex: 1;
+            border-radius: 100%;
+            border: 2px solid ${theme.border};
+          `}
+        />
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
I ran into a problem where expandable elements such as those on `DataView` and `Accordion` were measuring height dimensions incorrectly because `TokenAmount` wasn't mounted prior and hadn't loaded token images to render space.

A solution is to always provide the dimensions and a placeholder during load, this also stops content hopping around.

![image](https://user-images.githubusercontent.com/11708259/90800537-b42a3880-e30c-11ea-8880-bb0efbd48213.png)

This does present the question of whether a placeholder being present when a fake token is used is acceptable. I think we should optimise for the common use case (a token address has an asset) and if we need to we can give the option to hide the token graphic via a flag in the future.