### PR TITLE
chore: update stale bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,7 +3,7 @@
 addReviewers: true
 addAssignees: false
 
-reviewers: 
+reviewers:
   - bpierre
 
 skipKeywords:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,19 +1,11 @@
 # Configuration for https://probot.github.io/apps/stale
 
-daysUntilStale: 60
-daysUntilClose: 7
-
+only: pulls
 staleLabel: abandoned
-
-issues:
-  daysUntilStale: 180
-  markComment: >
-    This issue has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for contributing to Aragon! 🦅
 
 pulls:
   daysUntilStale: 30
+  daysUntilClose: 7
   markComment: >
     This pull request has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you


### PR DESCRIPTION
Removing the issue stale bot, since we usually do a pretty good job of closing them when they become irrelevant or fixed.